### PR TITLE
rpcserver: wait between peer connects

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -283,6 +283,19 @@ func connectToMatchedTrader(lndClient lnrpc.LightningClient,
 
 			continue
 		}
+
+		// Don't spam peer connections. This can lead to race errors in
+		// the itest when we try to connect to the same node in very
+		// short intervals.
+		//
+		// TODO(guggero): Fix this problem in lnd and also try to
+		// de-duplicate peers and their addresses to reduce connection
+		// tries.
+		time.Sleep(200 * time.Millisecond)
+
+		// We connected successfully, not need to try any of the other
+		// addresses.
+		break
 	}
 
 	// Since we specified perm, the error is async, and not fully


### PR DESCRIPTION
Found during an itest that opens two channels between the same nodes in the same batch. When connecting to the same peer in very short intervals, we get strange errors.

This isn't a proper fix but a workaround. The fix probably needs to be implemented in `lnd` and we should do some peer/address de-duplication for each batch execution.