### PR TITLE
order: increase precision for the smallest per-block lease rate 

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,13 +237,14 @@ single order for 10 million satoshis, wanting to receive 0.3% (30 bps)
 over a 3000 block period (a bit under 3 weeks):
 ```
 🏔 llm orders submit ask 10000000 0288096be9917f8ebdfc6eb2701635fe658f4eae1e0274dcce41418b3fb5145732 --interest_rate_percent=0.3 --max_duration_blocks=3000
+-- Order Details --
 Ask Amount: 0.1 BTC
 Ask Duration: 3000
-Total 0.0003 BTC Premium (paid to maker):
-Rate Fixed: 1
-Rate Per Block: 0.0000010 (0.0001000%)
+Total Premium (yield from taker): 0.0003 BTC
+Rate Fixed: 1000
+Rate Per Block: 0.000001000 (0.0001000%)
 Execution Fee:  0.00010001 BTC
-Confirm order (yes/no): eyes
+Confirm order (yes/no): yes
 {
         "accepted_order_nonce": "f1bebca6047dee6657f82377ebac94d1dc6667097f2a4d463deb63eff6f0dbcf"
 }
@@ -252,9 +253,10 @@ Confirm order (yes/no): eyes
 By leaving off the `--force` flag, we request the final break down to confirm
 the details of our order before we put it through.
 
-In this case, if this order is executed, then I'll gain 3k satoshis:
+In this case, if this order is executed, then I'll gain 30k satoshis:
 ```
-3000 = (1/100000)*1000000*3000
+premium = (rate_fixed / billion) * amount * blocks
+30,000 = (1,000/1,000,000,000)*1,000,000*3,000
 ```
 
 It's important to note that although internally we use a fixed rate per block

--- a/clmrpc/auctioneer.pb.go
+++ b/clmrpc/auctioneer.pb.go
@@ -1431,7 +1431,7 @@ type OrderMatchPrepare struct {
 	//allowed as a map key data type in protobuf.
 	MatchedOrders map[string]*MatchedOrder `protobuf:"bytes,1,rep,name=matched_orders,json=matchedOrders,proto3" json:"matched_orders,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	//
-	//The uniform clearing price rate in parts per million that was used for this
+	//The uniform clearing price rate in parts per billion that was used for this
 	//batch.
 	ClearingPriceRate uint32 `protobuf:"varint,2,opt,name=clearing_price_rate,json=clearingPriceRate,proto3" json:"clearing_price_rate,omitempty"`
 	//
@@ -2096,7 +2096,7 @@ type ServerOrder struct {
 	//The trader's account key of the account to use for the order.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
 	//
-	//Fixed order rate in parts per million.
+	//Fixed order rate in parts per billion.
 	RateFixed uint32 `protobuf:"varint,2,opt,name=rate_fixed,json=rateFixed,proto3" json:"rate_fixed,omitempty"`
 	//
 	//Order amount in satoshis.
@@ -2924,7 +2924,7 @@ type RelevantBatch struct {
 	//The set of orders that were matched against the orders belonging to the
 	//requested accounts.
 	MatchedOrders map[string]*MatchedOrder `protobuf:"bytes,4,rep,name=matched_orders,json=matchedOrders,proto3" json:"matched_orders,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	// The uniform clearing price rate in parts per million of the batch.
+	// The uniform clearing price rate in parts per billion of the batch.
 	ClearingPriceRate uint32 `protobuf:"varint,5,opt,name=clearing_price_rate,json=clearingPriceRate,proto3" json:"clearing_price_rate,omitempty"`
 	// The fee parameters used to calculate the execution fees.
 	ExecutionFee *ExecutionFee `protobuf:"bytes,6,opt,name=execution_fee,json=executionFee,proto3" json:"execution_fee,omitempty"`

--- a/clmrpc/auctioneer.proto
+++ b/clmrpc/auctioneer.proto
@@ -350,7 +350,7 @@ message OrderMatchPrepare {
     map<string, MatchedOrder> matched_orders = 1;
 
     /*
-    The uniform clearing price rate in parts per million that was used for this
+    The uniform clearing price rate in parts per billion that was used for this
     batch.
     */
     uint32 clearing_price_rate = 2;
@@ -636,7 +636,7 @@ message ServerOrder {
     bytes trader_key = 1;
 
     /*
-    Fixed order rate in parts per million.
+    Fixed order rate in parts per billion.
     */
     uint32 rate_fixed = 2;
 
@@ -872,7 +872,7 @@ message RelevantBatch {
     */
     map<string, MatchedOrder> matched_orders = 4;
 
-    // The uniform clearing price rate in parts per million of the batch.
+    // The uniform clearing price rate in parts per billion of the batch.
     uint32 clearing_price_rate = 5;
 
     // The fee parameters used to calculate the execution fees.
@@ -895,7 +895,7 @@ message ExecutionFee {
     uint64 base_fee = 1;
 
     /*
-    The fee rate in parts per million 
+    The fee rate in parts per million
     */
     uint64 fee_rate = 2;
 }

--- a/clmrpc/trader.pb.go
+++ b/clmrpc/trader.pb.go
@@ -1005,7 +1005,7 @@ type Order struct {
 	//The trader's account key of the account that is used for the order.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
 	//
-	//Fixed order rate in parts per million.
+	//Fixed order rate in parts per billion.
 	RateFixed uint32 `protobuf:"varint,2,opt,name=rate_fixed,json=rateFixed,proto3" json:"rate_fixed,omitempty"`
 	//
 	//Order amount in satoshis.

--- a/clmrpc/trader.proto
+++ b/clmrpc/trader.proto
@@ -264,7 +264,7 @@ message Order {
     bytes trader_key = 1;
 
     /*
-    Fixed order rate in parts per million.
+    Fixed order rate in parts per billion.
     */
     uint32 rate_fixed = 2;
 

--- a/clmrpc/trader.swagger.json
+++ b/clmrpc/trader.swagger.json
@@ -530,7 +530,7 @@
         "rate_fixed": {
           "type": "integer",
           "format": "int64",
-          "description": "Fixed order rate in parts per million."
+          "description": "Fixed order rate in parts per billion."
         },
         "amt": {
           "type": "string",

--- a/order/tradingfees.go
+++ b/order/tradingfees.go
@@ -10,10 +10,10 @@ import (
 )
 
 var (
-	// FeeRateTotalParts defines the granularity of the fee rate.
-	// Throughout the codebase, we'll use fix based arithmetic to compute
-	// fees.
-	FeeRateTotalParts = 1e6
+	// FeeRateTotalParts defines the granularity of the fixed rate used to
+	// compute the per-block interest rate.  Throughout the codebase, we'll
+	// use fix based arithmetic to compute fees.
+	FeeRateTotalParts = 1e9
 
 	// dustLimitP2WPKH is the minimum size of a P2WPKH output to not be
 	// considered dust.
@@ -51,7 +51,7 @@ func (f FixedRatePremium) LumpSumPremium(amt btcutil.Amount,
 	// Once we have this value, we can then multiply the premium paid per
 	// block times the number of compounding periods, or the total lease
 	// duration.
-	return btcutil.Amount(premiumPerBlock * float32(durationBlocks))
+	return btcutil.Amount(premiumPerBlock * float64(durationBlocks))
 }
 
 // FeeSchedule is an interface that represents the configuration source that
@@ -111,8 +111,8 @@ var _ FeeSchedule = (*LinearFeeSchedule)(nil)
 // PerBlockPremium calculates the absolute premium in fractions of satoshis for
 // a one block duration from the amount and the specified fee rate in parts per
 // million.
-func PerBlockPremium(amt btcutil.Amount, fixedRate uint32) float32 {
-	return float32(amt) * float32(fixedRate) / float32(FeeRateTotalParts)
+func PerBlockPremium(amt btcutil.Amount, fixedRate uint32) float64 {
+	return float64(amt) * float64(fixedRate) / FeeRateTotalParts
 }
 
 // EstimateTraderFee calculates the chain fees a trader has to pay for their


### PR DESCRIPTION
This is a follow up to #21. In this PR increase the fixed rate
denominator from 1e6 to 1e9 (a factor of 100x), which will allow us to
express a per-block lease rate for the smallest possible order (1 unit,
or 100k sats) over the longest possible lease period (6 months).