### PR TITLE
auctioneer: add quit chan to account subscription, fix shutdown hang

### DIFF
--- a/auctioneer/account_subscription.go
+++ b/auctioneer/account_subscription.go
@@ -21,6 +21,7 @@ type acctSubscription struct {
 	sendMsg    func(*clmrpc.ClientAuctionMessage) error
 	signer     lndclient.SignerClient
 	msgChan    chan *clmrpc.ServerAuctionMessage
+	quit       <-chan struct{}
 }
 
 // authenticate performs the 3-way authentication handshake between the trader
@@ -96,5 +97,8 @@ func (s *acctSubscription) authenticate(ctx context.Context) error {
 	case <-ctx.Done():
 		return fmt.Errorf("context canceled before challenge was " +
 			"received")
+
+	case <-s.quit:
+		return ErrClientShutdown
 	}
 }

--- a/auctioneer/client.go
+++ b/auctioneer/client.go
@@ -473,6 +473,7 @@ func (c *Client) connectAndAuthenticate(ctx context.Context,
 		sendMsg: c.SendAuctionMessage,
 		signer:  c.cfg.Signer,
 		msgChan: make(chan *clmrpc.ServerAuctionMessage),
+		quit:    c.quit,
 	}
 	c.subscribedAccts[acctPubKey] = sub
 	err := sub.authenticate(ctx)


### PR DESCRIPTION
To fix an issue where the trader daemon wouldn't properly shutdown if an
authentication was still ongoing, we add a quit chan to the account
subscription.