### PR TITLE
rpc: check nil funds destination in CloseAccountRequest

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -824,6 +824,9 @@ func (s *rpcServer) CloseAccount(ctx context.Context,
 		}
 
 		feeExpr = account.OutputsWithImplicitFee(outputs)
+
+	case nil:
+		return nil, errors.New("a funds destination must be specified")
 	}
 
 	dbOrders, err := s.server.db.GetOrders()


### PR DESCRIPTION
This addresses a panic when the funds destination field of the request is not populated.

Fixes https://github.com/lightninglabs/LLM/issues/57.