### PR TITLE
llmd: on start up only query orders that're in a non-terminal state

### DIFF
--- a/server.go
+++ b/server.go
@@ -441,6 +441,12 @@ func (s *Server) syncLocalOrderState() error {
 		orderNonce := dbOrder.Nonce()
 		localOrderState := dbOrder.Details().State
 
+		// If the order is cancelled or in any other terminal state, we
+		// don't need to query the server for its current status.
+		if localOrderState.Archived() {
+			continue
+		}
+
 		// For our comparison below, we'll poll the auctioneer to find
 		// out what state they think this order is in.
 		orderStateResp, err := s.AuctioneerClient.OrderState(


### PR DESCRIPTION
This lets us avoid querying the server for all orders on start up each
time.