### PR TITLE
Lower default max batch fee rate

### DIFF
--- a/cmd/pool/order.go
+++ b/cmd/pool/order.go
@@ -21,8 +21,8 @@ const (
 	defaultBidMinDuration = 144
 )
 
-// Default max batch fee rate to 500 sat/vbyte.
-const defaultMaxBatchFeeRateSatPerVByte = 500
+// Default max batch fee rate to 100 sat/vbyte.
+const defaultMaxBatchFeeRateSatPerVByte = 100
 
 var ordersCommands = []cli.Command{
 	{


### PR DESCRIPTION
A high max batch fee rate would reserve a lot of the account balance for
fees.

Note that if the actual fee rate goes higher than the max batch fee rate
set, then the orders won't be included in the batch, and the default
must be overridden.

Fixes https://github.com/lightninglabs/subasta/issues/169