### PR TITLE
multi: check tor address without port

### DIFF
--- a/order/manager.go
+++ b/order/manager.go
@@ -147,13 +147,11 @@ func (m *Manager) PrepareOrder(ctx context.Context, order Order,
 	copy(multiSigKey[:], nextMultiSigKey.PubKey.SerializeCompressed())
 	info, err := m.cfg.Lightning.GetInfo(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get local "+
-			"node info: %v", err)
+		return nil, fmt.Errorf("unable to get local node info: %v", err)
 	}
 	nodeAddrs, err := parseNodeUris(info.Uris)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse "+
-			"node uris: %v", err)
+		return nil, fmt.Errorf("unable to parse node uris: %v", err)
 	}
 
 	// If the order is a ask, then this means they should be an effective
@@ -376,10 +374,16 @@ func parseNodeUris(uris []string) ([]net.Addr, error) {
 			err  error
 		)
 
+		// Obtain the host to determine if this is a Tor address.
+		host, _, err := net.SplitHostPort(parts[1])
+		if err != nil {
+			host = parts[1]
+		}
+
 		switch {
 		// We'll need to parse onion addresses in a different manner as
 		// the encoding also differ from v2 to v3 addrs.
-		case tor.IsOnionHost(parts[1]):
+		case tor.IsOnionHost(host):
 			addr, err = parseOnionAddr(parts[1])
 			if err != nil {
 				return nil, err

--- a/order/rpc_parse.go
+++ b/order/rpc_parse.go
@@ -63,8 +63,14 @@ func parseNodeAddrs(rpcAddrs []*poolrpc.NodeAddress, orderIsAsk bool) ([]net.Add
 			err  error
 		)
 
+		// Obtain the host to determine if this is a Tor address.
+		host, _, err := net.SplitHostPort(rpcAddr.Addr)
+		if err != nil {
+			host = rpcAddr.Addr
+		}
+
 		switch {
-		case tor.IsOnionHost(rpcAddr.Addr):
+		case tor.IsOnionHost(host):
 			addr, err = parseOnionAddr(rpcAddr.Addr)
 
 		default:

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1719,7 +1720,13 @@ func rpcOrderStateToDBState(state poolrpc.OrderState) (order.State, error) {
 // of active Uris for a node.
 func nodeHasTorAddrs(nodeAddrs []string) bool {
 	for _, nodeAddr := range nodeAddrs {
-		if tor.IsOnionHost(nodeAddr) {
+		// Obtain the host to determine if this is a Tor address.
+		host, _, err := net.SplitHostPort(nodeAddr)
+		if err != nil {
+			host = nodeAddr
+		}
+
+		if tor.IsOnionHost(host) {
 			return true
 		}
 	}


### PR DESCRIPTION
The underlying call to tor.IsOnionHost used to detect Tor addresses requires the host only, without the port.

Fixes https://github.com/lightninglabs/subasta/issues/191.