### PR TITLE
rpcserver: request proper shutdown on terminal error

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/signal"
 	"github.com/lightningnetwork/lnd/tor"
 )
 
@@ -308,11 +309,7 @@ func (s *rpcServer) serverHandler(blockChan chan int32, blockErrChan chan error)
 			if err != nil && !errors.Is(err, order.ErrMismatchErr) {
 				rpcLog.Errorf("Error handling server message: %v",
 					err)
-				err := s.server.Stop()
-				if err != nil {
-					rpcLog.Errorf("Error shutting down: %v",
-						err)
-				}
+				signal.RequestShutdown()
 			}
 
 		case err := <-s.auctioneer.StreamErrChan:
@@ -337,11 +334,7 @@ func (s *rpcServer) serverHandler(blockChan chan int32, blockErrChan chan error)
 			if err != nil {
 				rpcLog.Errorf("Unable to receive block "+
 					"notification: %v", err)
-				err := s.server.Stop()
-				if err != nil {
-					rpcLog.Errorf("Error shutting down: %v",
-						err)
-				}
+				signal.RequestShutdown()
 			}
 
 		// In case the server is shutting down.


### PR DESCRIPTION
When a terminal error is received, it is not enough to stop the server
itself to terminate the trader daemon because the main goroutine still
blocks on the read from the shutdown channel.
Instead we have to request a proper shutdown through the signal package
to initiate a full trader daemon stop.