### PR TITLE
pool: round default min chan amt to nearest unit

### DIFF
--- a/order/supplyunit.go
+++ b/order/supplyunit.go
@@ -10,7 +10,7 @@ type SupplyUnit uint64
 const (
 	// BaseSupplyUnit is the smallest channel that can be bought or sold in
 	// the system. These units are expressed in satoshis.
-	BaseSupplyUnit SupplyUnit = 100_000
+	BaseSupplyUnit btcutil.Amount = 100_000
 )
 
 // NewSupplyFromSats calculates the number of supply units that can be bought or
@@ -19,6 +19,12 @@ func NewSupplyFromSats(sats btcutil.Amount) SupplyUnit {
 	// TODO(roasbeef): ensure proper rounding, etc.
 
 	return SupplyUnit(uint64(sats) / uint64(BaseSupplyUnit))
+}
+
+// RoundToNextSupplyUnit computes and rounds to the next whole number of supply
+// units from the given amount in satoshis.
+func RoundToNextSupplyUnit(sats btcutil.Amount) SupplyUnit {
+	return SupplyUnit((sats + BaseSupplyUnit - 1) / BaseSupplyUnit)
 }
 
 // ToSatoshis maps a set number of supply units to the corresponding number of

--- a/order/supplyunit_test.go
+++ b/order/supplyunit_test.go
@@ -1,0 +1,34 @@
+package order_test
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/pool/order"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRoundToNextSupplyUnit runs a quick check scenario to ensure the
+// correctness of RoundToNextSupplyUnit.
+func TestRoundToNextSupplyUnit(t *testing.T) {
+	t.Parallel()
+
+	f := func(sats btcutil.Amount) bool {
+		units := order.RoundToNextSupplyUnit(sats)
+		if sats%order.BaseSupplyUnit == 0 {
+			return units == order.NewSupplyFromSats(sats)
+		}
+		return units == order.NewSupplyFromSats(sats)+1
+	}
+
+	cfg := &quick.Config{
+		Values: func(v []reflect.Value, r *rand.Rand) {
+			v[0] = reflect.ValueOf(btcutil.Amount(r.Int63()))
+		},
+	}
+
+	require.NoError(t, quick.Check(f, cfg))
+}


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/pool/issues/145.