### PR TITLE
Add debug CLI and wrap errors

### DIFF
--- a/auctioneer/batch.go
+++ b/auctioneer/batch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/btcsuite/btcd/wire"
@@ -41,7 +42,7 @@ func (c *Client) checkPendingBatch() error {
 		return nil
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("loading pending batch failed: %v", err)
 	}
 
 	finalizedTx, err := c.finalizedBatchTx(id)
@@ -53,7 +54,7 @@ func (c *Client) checkPendingBatch() error {
 		return nil
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("querying finalized batch TX failed: %v", err)
 	}
 
 	if tx.TxHash() != finalizedTx.TxHash() {
@@ -69,13 +70,14 @@ func (c *Client) finalizedBatchTx(id order.BatchID) (*wire.MsgTx, error) {
 	req := &poolrpc.RelevantBatchRequest{Id: id[:]}
 	batch, err := c.client.RelevantBatchSnapshot(context.Background(), req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("querying relevant batch snapshot "+
+			"failed: %v", err)
 	}
 
 	var batchTx wire.MsgTx
 	err = batchTx.Deserialize(bytes.NewReader(batch.Transaction))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("deserializing batch TX failed: %v", err)
 	}
 
 	return &batchTx, nil

--- a/auctioneer/client.go
+++ b/auctioneer/client.go
@@ -477,7 +477,8 @@ func (c *Client) connectAndAuthenticate(ctx context.Context,
 	if c.serverStream == nil {
 		err := c.connectServerStream(0, initialConnectRetries)
 		if err != nil {
-			return sub, false, err
+			return sub, false, fmt.Errorf("connecting server "+
+				"stream failed: %v", err)
 		}
 
 		// Since this is the first time we establish our connection to
@@ -485,7 +486,8 @@ func (c *Client) connectAndAuthenticate(ctx context.Context,
 		// batch as finalized, or if we need to remove it due to the
 		// batch auction no longer including us.
 		if err := c.checkPendingBatch(); err != nil {
-			return sub, false, err
+			return sub, false, fmt.Errorf("checking pending "+
+				"batch failed: %v", err)
 		}
 	}
 

--- a/clientdb/account_test.go
+++ b/clientdb/account_test.go
@@ -51,7 +51,7 @@ func newTestDB(t *testing.T) (*DB, func()) {
 		t.Fatalf("unable to create temp dir: %v", err)
 	}
 
-	db, err := New(tempDir)
+	db, err := New(tempDir, DBFilename)
 	if err != nil {
 		os.RemoveAll(tempDir)
 		t.Fatalf("unable to create new db: %v", err)

--- a/clientdb/db.go
+++ b/clientdb/db.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	// dbFilename is the default filename of the client database.
-	dbFilename = "pool.db"
+	// DBFilename is the default filename of the client database.
+	DBFilename = "pool.db"
 
 	// dbFilePermission is the default permission the client database file
 	// is created with.
@@ -29,9 +29,9 @@ type DB struct {
 }
 
 // New creates a new bolt database that can be found at the given directory.
-func New(dir string) (*DB, error) {
+func New(dir, fileName string) (*DB, error) {
 	firstInit := false
-	path := filepath.Join(dir, dbFilename)
+	path := filepath.Join(dir, fileName)
 
 	// If the database file does not exist yet, create its directory.
 	if !fileExists(path) {

--- a/cmd/pool/debug.go
+++ b/cmd/pool/debug.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"path/filepath"
+
+	"github.com/lightninglabs/pool"
+	"github.com/lightninglabs/pool/auctioneer"
+	"github.com/lightninglabs/pool/clientdb"
+	"github.com/lightninglabs/pool/order"
+	"github.com/lightninglabs/pool/poolrpc"
+	"github.com/lightninglabs/pool/terms"
+	"github.com/lightningnetwork/lnd/lncfg"
+	"github.com/urfave/cli"
+)
+
+var debugCommands = []cli.Command{
+	{
+		Name:      "debug",
+		ShortName: "d",
+		Usage:     "Debug the local trader state.",
+		Hidden:    true,
+		Subcommands: []cli.Command{
+			dumpAccountsCommand,
+			dumpOrdersCommand,
+			dumpPendingBatcheCommand,
+			removePendingBatchCommand,
+		},
+	},
+}
+
+var dumpAccountsCommand = cli.Command{
+	Name:      "dumpaccounts",
+	ShortName: "da",
+	Usage:     "dump all accounts contained in the local database",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name: "db",
+			Usage: "the specific pool database to use instead " +
+				"of the default one on ~/.pool/<network>/" +
+				"pool.db",
+		},
+	},
+	Action: dumpAccounts,
+}
+
+func dumpAccounts(ctx *cli.Context) error {
+	db, err := getPoolDB(ctx)
+	if err != nil {
+		return fmt.Errorf("error loading DB: %v", err)
+	}
+
+	accounts, err := db.Accounts()
+	if err != nil {
+		return fmt.Errorf("error loading accounts: %v", err)
+	}
+
+	rpcAccounts := make([]*poolrpc.Account, len(accounts))
+	for idx, acct := range accounts {
+		rpcAcct, err := pool.MarshallAccount(acct)
+		if err != nil {
+			return fmt.Errorf("error marshalling account: %v", err)
+		}
+		rpcAccounts[idx] = rpcAcct
+	}
+
+	printRespJSON(&poolrpc.ListAccountsResponse{Accounts: rpcAccounts})
+
+	return nil
+}
+
+var dumpOrdersCommand = cli.Command{
+	Name:      "dumporders",
+	ShortName: "do",
+	Usage:     "dump all orders contained in the local database",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name: "db",
+			Usage: "the specific pool database to use instead " +
+				"of the default one on ~/.pool/<network>/" +
+				"pool.db",
+		},
+	},
+	Action: dumpOrders,
+}
+
+func dumpOrders(ctx *cli.Context) error {
+	db, err := getPoolDB(ctx)
+	if err != nil {
+		return fmt.Errorf("error loading DB: %v", err)
+	}
+
+	orders, err := db.GetOrders()
+	if err != nil {
+		return fmt.Errorf("error loading orders: %v", err)
+	}
+
+	asks := make([]*poolrpc.Ask, 0, len(orders))
+	bids := make([]*poolrpc.Bid, 0, len(orders))
+	for _, dbOrder := range orders {
+		nonce := dbOrder.Nonce()
+		dbDetails := dbOrder.Details()
+
+		orderState, err := pool.DBOrderStateToRPCState(dbDetails.State)
+		if err != nil {
+			return err
+		}
+
+		details := &poolrpc.Order{
+			TraderKey: dbDetails.AcctKey[:],
+			RateFixed: dbDetails.FixedRate,
+			Amt:       uint64(dbDetails.Amt),
+			MaxBatchFeeRateSatPerKw: uint64(
+				dbDetails.MaxBatchFeeRate,
+			),
+			OrderNonce:       nonce[:],
+			State:            orderState,
+			Units:            uint32(dbDetails.Units),
+			UnitsUnfulfilled: uint32(dbDetails.UnitsUnfulfilled),
+			ReservedValueSat: uint64(dbOrder.ReservedValue(
+				terms.NewLinearFeeSchedule(0, 0),
+			)),
+			CreationTimestampNs: uint64(0),
+			MinUnitsMatch: uint32(
+				dbOrder.Details().MinUnitsMatch,
+			),
+		}
+
+		switch o := dbOrder.(type) {
+		case *order.Ask:
+			rpcAsk := &poolrpc.Ask{
+				Details:             details,
+				LeaseDurationBlocks: dbDetails.LeaseDuration,
+				Version:             uint32(o.Version),
+			}
+			asks = append(asks, rpcAsk)
+
+		case *order.Bid:
+			nodeTier, err := auctioneer.MarshallNodeTier(
+				o.MinNodeTier,
+			)
+			if err != nil {
+				return err
+			}
+
+			rpcBid := &poolrpc.Bid{
+				Details:             details,
+				LeaseDurationBlocks: dbDetails.LeaseDuration,
+				Version:             uint32(o.Version),
+				MinNodeTier:         nodeTier,
+			}
+			bids = append(bids, rpcBid)
+
+		default:
+			return fmt.Errorf("unknown order type: %v", o)
+		}
+	}
+
+	printRespJSON(&poolrpc.ListOrdersResponse{Asks: asks, Bids: bids})
+
+	return nil
+}
+
+var dumpPendingBatcheCommand = cli.Command{
+	Name:      "dumppendingbatch",
+	ShortName: "dpb",
+	Usage: "dump the current pending batch contained in the local " +
+		"database",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name: "db",
+			Usage: "the specific pool database to use instead " +
+				"of the default one on ~/.pool/<network>/" +
+				"pool.db",
+		},
+	},
+	Action: dumpPendingBatch,
+}
+
+func dumpPendingBatch(ctx *cli.Context) error {
+	db, err := getPoolDB(ctx)
+	if err != nil {
+		return fmt.Errorf("error loading DB: %v", err)
+	}
+
+	batchID, tx, err := db.PendingBatch()
+	if err != nil {
+		return fmt.Errorf("error getting pending batch: %v", err)
+	}
+
+	fmt.Printf("Batch ID:\t%x\n", batchID[:])
+	fmt.Printf("TXID:\t\t%s\n", tx.TxHash())
+
+	var buf bytes.Buffer
+	err = tx.Serialize(&buf)
+	if err != nil {
+		return fmt.Errorf("error serializing TX: %v", err)
+	}
+	fmt.Printf("Raw TX:\t\t%x\n", buf.Bytes())
+
+	return nil
+}
+
+var removePendingBatchCommand = cli.Command{
+	Name:      "removependingbatch",
+	ShortName: "rpb",
+	Usage:     "remove the current pending batch from the local database",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name: "db",
+			Usage: "the specific pool database to use instead " +
+				"of the default one on ~/.pool/<network>/" +
+				"pool.db",
+		},
+	},
+	Action: removePendingBatch,
+}
+
+func removePendingBatch(ctx *cli.Context) error {
+	db, err := getPoolDB(ctx)
+	if err != nil {
+		return fmt.Errorf("error loading DB: %v", err)
+	}
+
+	return db.DeletePendingBatch()
+}
+
+func getPoolDB(ctx *cli.Context) (*clientdb.DB, error) {
+	fullDbPath := filepath.Join(
+		pool.DefaultBaseDir, ctx.GlobalString("network"),
+		clientdb.DBFilename,
+	)
+	if ctx.IsSet("db") {
+		fullDbPath = lncfg.CleanAndExpandPath(ctx.String("db"))
+	}
+
+	db, err := clientdb.New(path.Dir(fullDbPath), path.Base(fullDbPath))
+	if err != nil {
+		return nil, fmt.Errorf("error opening DB at %v: %v", fullDbPath,
+			err)
+	}
+
+	return db, nil
+}

--- a/cmd/pool/main.go
+++ b/cmd/pool/main.go
@@ -126,6 +126,7 @@ func main() {
 	app.Commands = append(app.Commands, ordersCommands...)
 	app.Commands = append(app.Commands, auctionCommands...)
 	app.Commands = append(app.Commands, listAuthCommand)
+	app.Commands = append(app.Commands, debugCommands...)
 
 	err := app.Run(os.Args)
 	if err != nil {

--- a/fundingmgr_test.go
+++ b/fundingmgr_test.go
@@ -199,7 +199,7 @@ func newManagerHarness(t *testing.T) *managerHarness {
 	tempDir, err := ioutil.TempDir("", "client-db")
 	require.NoError(t, err)
 
-	db, err := clientdb.New(tempDir)
+	db, err := clientdb.New(tempDir, clientdb.DBFilename)
 	if err != nil {
 		_ = os.RemoveAll(tempDir)
 		t.Fatalf("unable to create new db: %v", err)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -586,7 +586,7 @@ func (s *rpcServer) InitAccount(ctx context.Context,
 		return nil, err
 	}
 
-	return marshallAccount(acct)
+	return MarshallAccount(acct)
 }
 
 func (s *rpcServer) ListAccounts(ctx context.Context,
@@ -604,7 +604,7 @@ func (s *rpcServer) ListAccounts(ctx context.Context,
 			continue
 		}
 
-		rpcAccount, err := marshallAccount(acct)
+		rpcAccount, err := MarshallAccount(acct)
 		if err != nil {
 			return nil, err
 		}
@@ -671,7 +671,8 @@ func (s *rpcServer) ListAccounts(ctx context.Context,
 	}, nil
 }
 
-func marshallAccount(a *account.Account) (*poolrpc.Account, error) {
+// MarshallAccount returns the RPC representation of an account.
+func MarshallAccount(a *account.Account) (*poolrpc.Account, error) {
 	var rpcState poolrpc.AccountState
 	switch a.State {
 	case account.StateInitiated, account.StatePendingOpen:
@@ -753,7 +754,7 @@ func (s *rpcServer) DepositAccount(ctx context.Context,
 		return nil, err
 	}
 
-	rpcModifiedAccount, err := marshallAccount(modifiedAccount)
+	rpcModifiedAccount, err := MarshallAccount(modifiedAccount)
 	if err != nil {
 		return nil, err
 	}
@@ -805,7 +806,7 @@ func (s *rpcServer) WithdrawAccount(ctx context.Context,
 		return nil, err
 	}
 
-	rpcModifiedAccount, err := marshallAccount(modifiedAccount)
+	rpcModifiedAccount, err := MarshallAccount(modifiedAccount)
 	if err != nil {
 		return nil, err
 	}
@@ -1259,7 +1260,7 @@ func (s *rpcServer) ListOrders(ctx context.Context,
 			continue
 		}
 
-		orderState, err := dbOrderStateToRPCState(dbDetails.State)
+		orderState, err := DBOrderStateToRPCState(dbDetails.State)
 		if err != nil {
 			return nil, err
 		}
@@ -1989,9 +1990,9 @@ func rpcOrderStateToDBState(state poolrpc.OrderState) (order.State, error) {
 	}
 }
 
-// dbOrderStateToRPCState maps the order state as stored in the database to the
+// DBOrderStateToRPCState maps the order state as stored in the database to the
 // corresponding RPC enum type.
-func dbOrderStateToRPCState(state order.State) (poolrpc.OrderState, error) {
+func DBOrderStateToRPCState(state order.State) (poolrpc.OrderState, error) {
 	switch state {
 	case order.StateSubmitted:
 		return poolrpc.OrderState_ORDER_SUBMITTED, nil
@@ -2064,11 +2065,11 @@ func dbEventsToRPCEvents(dbEvents []event.Event) ([]*poolrpc.OrderEvent,
 			// itself is stored for this event type.
 
 		case *clientdb.UpdatedEvent:
-			prevState, err := dbOrderStateToRPCState(e.PrevState)
+			prevState, err := DBOrderStateToRPCState(e.PrevState)
 			if err != nil {
 				return nil, err
 			}
-			newState, err := dbOrderStateToRPCState(e.NewState)
+			newState, err := DBOrderStateToRPCState(e.NewState)
 			if err != nil {
 				return nil, err
 			}

--- a/server.go
+++ b/server.go
@@ -378,7 +378,7 @@ func (s *Server) setupClient() error {
 
 	// Open the main database.
 	var err error
-	s.db, err = clientdb.New(s.cfg.BaseDir)
+	s.db, err = clientdb.New(s.cfg.BaseDir, clientdb.DBFilename)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a debug CLI that helps inspecting a local trader database. Also wraps some errors to give more information about the cause.

EDIT: The advantage of these commands is that they work without starting the trader daemon (so no interaction with the server) and also work on databases of other users, as no interaction with lnd is required either.
Perhaps it's really just something we'll use and it doesn't need to be in the main code base. But I've hidden the command group so most people won't notice this.