### PR TITLE
Clean up pending batch artifacts on startup

### DIFF
--- a/auctioneer/batch.go
+++ b/auctioneer/batch.go
@@ -25,7 +25,10 @@ type BatchSource interface {
 	// PendingBatchSnapshot retrieves the snapshot of the currently pending
 	// batch. If there isn't one, account.ErrNoPendingBatch is returned.
 	PendingBatchSnapshot() (*clientdb.LocalBatchSnapshot, error)
+}
 
+// BatchCleaner abstracts the cleaning up of a trader's pending batch.
+type BatchCleaner interface {
 	// DeletePendingBatch removes all references to the current pending
 	// batch without applying its staged updates to accounts and orders. If
 	// no pending batch exists, this acts as a no-op.
@@ -58,7 +61,7 @@ func (c *Client) checkPendingBatch() error {
 	}
 
 	if snapshot.BatchTX.TxHash() != finalizedTx.TxHash() {
-		return c.cfg.BatchSource.DeletePendingBatch()
+		return c.cfg.BatchCleaner.DeletePendingBatch()
 	}
 
 	return nil

--- a/auctioneer/batch.go
+++ b/auctioneer/batch.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/pool/account"
-	"github.com/lightninglabs/pool/order"
+	"github.com/lightninglabs/pool/clientdb"
 	"github.com/lightninglabs/pool/poolrpc"
 )
 
@@ -22,9 +22,9 @@ var (
 
 // BatchSource abstracts the source of a trader's pending batch.
 type BatchSource interface {
-	// PendingBatch retrieves the ID and transaction of the current pending
-	// batch. If one does not exist, account.ErrNoPendingBatch is returned.
-	PendingBatch() (order.BatchID, *wire.MsgTx, error)
+	// PendingBatchSnapshot retrieves the snapshot of the currently pending
+	// batch. If there isn't one, account.ErrNoPendingBatch is returned.
+	PendingBatchSnapshot() (*clientdb.LocalBatchSnapshot, error)
 
 	// DeletePendingBatch removes all references to the current pending
 	// batch without applying its staged updates to accounts and orders. If
@@ -36,7 +36,7 @@ type BatchSource interface {
 // auctioneer considers finalized. If they don't match, then the pending batch
 // is deleted without applying its staged updates.
 func (c *Client) checkPendingBatch() error {
-	id, tx, err := c.cfg.BatchSource.PendingBatch()
+	snapshot, err := c.cfg.BatchSource.PendingBatchSnapshot()
 	if err == account.ErrNoPendingBatch {
 		// If there's no pending batch, there's nothing to do.
 		return nil
@@ -45,7 +45,7 @@ func (c *Client) checkPendingBatch() error {
 		return fmt.Errorf("loading pending batch failed: %v", err)
 	}
 
-	finalizedTx, err := c.finalizedBatchTx(id)
+	finalizedTx, err := c.finalizedBatchTx(snapshot)
 	// If the batch has not been finalized yet, there's nothing to do but
 	// wait to receive its Finalize message.
 	//
@@ -57,7 +57,7 @@ func (c *Client) checkPendingBatch() error {
 		return fmt.Errorf("querying finalized batch TX failed: %v", err)
 	}
 
-	if tx.TxHash() != finalizedTx.TxHash() {
+	if snapshot.BatchTX.TxHash() != finalizedTx.TxHash() {
 		return c.cfg.BatchSource.DeletePendingBatch()
 	}
 
@@ -66,8 +66,10 @@ func (c *Client) checkPendingBatch() error {
 
 // finalizedBatchTx retrieves the finalized transaction of a batch according to
 // the auctioneer, i.e., the transaction that will be broadcast to the network.
-func (c *Client) finalizedBatchTx(id order.BatchID) (*wire.MsgTx, error) {
-	req := &poolrpc.BatchSnapshotRequest{BatchId: id[:]}
+func (c *Client) finalizedBatchTx(
+	snapshot *clientdb.LocalBatchSnapshot) (*wire.MsgTx, error) {
+
+	req := &poolrpc.BatchSnapshotRequest{BatchId: snapshot.BatchID[:]}
 	batch, err := c.client.BatchSnapshot(context.Background(), req)
 	if err != nil {
 		return nil, fmt.Errorf("querying relevant batch snapshot "+

--- a/auctioneer/client.go
+++ b/auctioneer/client.go
@@ -88,6 +88,10 @@ type Config struct {
 	// BatchSource provides information about the current pending batch, if
 	// any.
 	BatchSource BatchSource
+
+	// BatchCleaner provides functionality to clean up the state of a
+	// trader's pending batch.
+	BatchCleaner BatchCleaner
 }
 
 // Client performs the client side part of auctions. This interface exists to be

--- a/clientdb/batch.go
+++ b/clientdb/batch.go
@@ -1,10 +1,8 @@
 package clientdb
 
 import (
-	"bytes"
 	"fmt"
 
-	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/pool/account"
 	"github.com/lightninglabs/pool/order"
 	"go.etcd.io/bbolt"
@@ -18,10 +16,6 @@ var (
 	// pendingBatchIDKey is a key we'll use to store the ID of a batch we're
 	// currently participating in.
 	pendingBatchIDKey = []byte("pending-id")
-
-	// pendingBatchTxKey is a key we'll use to store the transaction of a
-	// batch we're currently participating in.
-	pendingBatchTxKey = []byte("pending-tx")
 
 	// pendingBatchAccountsBucketKey is the key of a bucket nested within
 	// the top level batch bucket that is responsible for storing the
@@ -130,14 +124,6 @@ func (db *DB) StorePendingBatch(batch *order.Batch, orders []order.Nonce,
 		if err := bucket.Put(pendingBatchIDKey, batchID[:]); err != nil {
 			return err
 		}
-		var buf bytes.Buffer
-		if err := WriteElement(&buf, batch.BatchTX); err != nil {
-			return err
-		}
-
-		if err = bucket.Put(pendingBatchTxKey, buf.Bytes()); err != nil {
-			return err
-		}
 
 		// Before we are done, we store a snapshot of the this batch,
 		// so we retain this history for later.
@@ -182,27 +168,6 @@ func pendingBatchID(tx *bbolt.Tx) (order.BatchID, error) {
 	return batchID, nil
 }
 
-// pendingBatchTx retrieves the stored pending batch transaction within a
-// database transaction.
-func pendingBatchTx(tx *bbolt.Tx) (*wire.MsgTx, error) {
-	bucket, err := getBucket(tx, batchBucketKey)
-	if err != nil {
-		return nil, err
-	}
-
-	rawBatchTx := bucket.Get(pendingBatchTxKey)
-	if rawBatchTx == nil {
-		return nil, account.ErrNoPendingBatch
-	}
-
-	var batchTx *wire.MsgTx
-	if err := ReadElement(bytes.NewReader(rawBatchTx), &batchTx); err != nil {
-		return nil, err
-	}
-
-	return batchTx, nil
-}
-
 // DeletePendingBatch removes all references to the current pending batch
 // without applying its staged updates to accounts and orders. If no pending
 // batch exists, this acts as a no-op.
@@ -214,9 +179,6 @@ func (db *DB) DeletePendingBatch() error {
 		}
 
 		if err := bucket.Delete(pendingBatchIDKey); err != nil {
-			return err
-		}
-		if err := bucket.Delete(pendingBatchTxKey); err != nil {
 			return err
 		}
 		err = bucket.DeleteBucket(pendingBatchAccountsBucketKey)
@@ -320,10 +282,6 @@ func applyBatchUpdates(tx *bbolt.Tx) error {
 		return err
 	}
 
-	// Finally, remove the reference to the pending batch ID and
-	// transaction.
-	if err := bucket.Delete(pendingBatchIDKey); err != nil {
-		return err
-	}
-	return bucket.Delete(pendingBatchTxKey)
+	// Finally, remove the reference to the pending batch ID.
+	return bucket.Delete(pendingBatchIDKey)
 }

--- a/clientdb/batch.go
+++ b/clientdb/batch.go
@@ -152,24 +152,16 @@ func (db *DB) StorePendingBatch(batch *order.Batch, orders []order.Nonce,
 	})
 }
 
-// PendingBatchID retrieves the ID of the currently pending batch. If there
-// isn't one, account.ErrNoPendingBatch is returned.
-func (db *DB) PendingBatch() (order.BatchID, *wire.MsgTx, error) {
-	var (
-		batchID order.BatchID
-		batchTx *wire.MsgTx
-	)
+// PendingBatchSnapshot retrieves the snapshot of the currently pending batch.
+// If there isn't one, account.ErrNoPendingBatch is returned.
+func (db *DB) PendingBatchSnapshot() (*LocalBatchSnapshot, error) {
+	var batchSnapshot *LocalBatchSnapshot
 	err := db.View(func(tx *bbolt.Tx) error {
 		var err error
-		batchID, err = pendingBatchID(tx)
-		if err != nil {
-			return err
-		}
-
-		batchTx, err = pendingBatchTx(tx)
+		batchSnapshot, err = fetchPendingBatchSnapshot(tx)
 		return err
 	})
-	return batchID, batchTx, err
+	return batchSnapshot, err
 }
 
 // pendingBatchID retrieves the stored pending batch ID within a database

--- a/clientdb/batch_snapshot.go
+++ b/clientdb/batch_snapshot.go
@@ -308,6 +308,22 @@ func storePendingBatchSnapshot(tx *bbolt.Tx,
 	return topBucket.Put(batchSnapshotPendingKey, buf.Bytes())
 }
 
+// fetchPendingBatchSnapshot retrieves the currently pending batch snapshot from
+// the database or returns the account.ErrNoPendingBatch error if none exists.
+func fetchPendingBatchSnapshot(tx *bbolt.Tx) (*LocalBatchSnapshot, error) {
+	topBucket, err := getBucket(tx, batchSnapshotBucketKey)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotBytes := topBucket.Get(batchSnapshotPendingKey)
+	if len(snapshotBytes) == 0 {
+		return nil, account.ErrNoPendingBatch
+	}
+
+	return deserializeLocalBatchSnapshot(bytes.NewReader(snapshotBytes))
+}
+
 // finalizeBatchSnapshot moves the pending batch snapshot into the sub-bucket
 // indexed by sequence numbers.
 func finalizeBatchSnapshot(tx *bbolt.Tx, batchID order.BatchID) error {

--- a/clientdb/batch_test.go
+++ b/clientdb/batch_test.go
@@ -403,10 +403,6 @@ func TestDeletePendingBatch(t *testing.T) {
 				return fmt.Errorf("found unexpected key %v",
 					string(pendingBatchIDKey))
 			}
-			if (root.Get(pendingBatchTxKey) != nil) != exists {
-				return fmt.Errorf("found unexpected key %v",
-					string(pendingBatchTxKey))
-			}
 			if (root.Bucket(pendingBatchAccountsBucketKey) != nil) != exists {
 				return fmt.Errorf("found unexpected bucket %v",
 					string(pendingBatchAccountsBucketKey))

--- a/clientdb/batch_test.go
+++ b/clientdb/batch_test.go
@@ -113,7 +113,7 @@ var (
 			runTest: func(db *DB, a *order.Ask, b *order.Bid,
 				acct *account.Account) error {
 
-				_, _, err := db.PendingBatch()
+				_, err := db.PendingBatchSnapshot()
 				return err
 			},
 		},
@@ -155,20 +155,20 @@ var (
 
 				// The pending batch ID and transaction should
 				// reflect correctly.
-				dbBatchID, dbBatchTx, err := db.PendingBatch()
+				dbSnapshot, err := db.PendingBatchSnapshot()
 				if err != nil {
 					return err
 				}
-				if dbBatchID != testBatchID {
+				if dbSnapshot.BatchID != testBatchID {
 					return fmt.Errorf("expected pending "+
 						"batch id %x, got %x",
-						testBatchID, dbBatchID)
+						testBatchID, dbSnapshot.BatchID)
 				}
-				if dbBatchTx.TxHash() != testBatch.BatchTX.TxHash() {
+				if dbSnapshot.BatchTX.TxHash() != testBatch.BatchTX.TxHash() {
 					return fmt.Errorf("expected pending "+
 						"batch tx %v, got %v",
 						testBatch.BatchTX.TxHash(),
-						dbBatchTx.TxHash())
+						dbSnapshot.BatchTX.TxHash())
 				}
 
 				// Verify the updates have not been applied to

--- a/cmd/pool/debug.go
+++ b/cmd/pool/debug.go
@@ -185,16 +185,16 @@ func dumpPendingBatch(ctx *cli.Context) error {
 		return fmt.Errorf("error loading DB: %v", err)
 	}
 
-	batchID, tx, err := db.PendingBatch()
+	snapshot, err := db.PendingBatchSnapshot()
 	if err != nil {
 		return fmt.Errorf("error getting pending batch: %v", err)
 	}
 
-	fmt.Printf("Batch ID:\t%x\n", batchID[:])
-	fmt.Printf("TXID:\t\t%s\n", tx.TxHash())
+	fmt.Printf("Batch ID:\t%x\n", snapshot.BatchID[:])
+	fmt.Printf("TXID:\t\t%s\n", snapshot.BatchTX.TxHash())
 
 	var buf bytes.Buffer
-	err = tx.Serialize(&buf)
+	err = snapshot.BatchTX.Serialize(&buf)
 	if err != nil {
 		return fmt.Errorf("error serializing TX: %v", err)
 	}

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -607,10 +607,21 @@ func (m *Manager) BatchChannelSetup(batch *order.Batch,
 	return channelKeys, nil
 }
 
+// DeletePendingBatch removes all references to the current pending batch
+// without applying its staged updates to accounts and orders. If no pending
+// batch exists, this acts as a no-op.
+//
+// NOTE: This is part of the auctioneer.BatchCleaner interface.
+func (m *Manager) DeletePendingBatch() error {
+	return m.DB.DeletePendingBatch()
+}
+
 // RemovePendingBatchArtifacts removes any funding shims or pending channels
 // from a batch that was never finalized. Some non-terminal errors are logged
 // only and not returned. Therefore if this method returns an error, it should
 // be handled as terminal error.
+//
+// NOTE: This is part of the auctioneer.BatchCleaner interface.
 func (m *Manager) RemovePendingBatchArtifacts(
 	matchedOrders map[order.Nonce][]*order.MatchedOrder,
 	batchTx *wire.MsgTx) error {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -60,7 +60,6 @@ type rpcServer struct {
 	auctioneer     *auctioneer.Client
 	accountManager *account.Manager
 	orderManager   *order.Manager
-	fundingManager *funding.Manager
 
 	quit                           chan struct{}
 	wg                             sync.WaitGroup
@@ -115,17 +114,6 @@ func newRPCServer(server *Server) *rpcServer {
 			Wallet:    lndServices.WalletKit,
 			Signer:    lndServices.Signer,
 		}),
-		fundingManager: &funding.Manager{
-			DB:               server.db,
-			WalletKit:        lndServices.WalletKit,
-			LightningClient:  lndServices.Client,
-			BaseClient:       server.lndClient,
-			BatchStepTimeout: funding.DefaultBatchStepTimeout,
-			PendingOpenChannels: make(
-				chan *lnrpc.ChannelEventUpdate_PendingOpenChannel,
-			),
-			NewNodesOnly: server.cfg.NewNodesOnly,
-		},
 		quit: make(chan struct{}),
 	}
 }
@@ -249,7 +237,7 @@ func (s *rpcServer) consumePendingOpenChannels(
 		}
 
 		select {
-		case s.fundingManager.PendingOpenChannels <- channel:
+		case s.server.fundingManager.PendingOpenChannels <- channel:
 		case <-s.quit:
 			return
 		}
@@ -379,7 +367,7 @@ func (s *rpcServer) handleServerMessage(rpcMsg *poolrpc.ServerAuctionMessage) er
 		// will never be published.
 		if s.orderManager.HasPendingBatch() {
 			pendingBatch := s.orderManager.PendingBatch()
-			err = s.fundingManager.RemovePendingBatchArtifacts(
+			err = s.server.fundingManager.RemovePendingBatchArtifacts(
 				pendingBatch.MatchedOrders, pendingBatch.BatchTX,
 			)
 			if err != nil {
@@ -415,7 +403,7 @@ func (s *rpcServer) handleServerMessage(rpcMsg *poolrpc.ServerAuctionMessage) er
 		// Before we accept the batch, we'll finish preparations on our
 		// end which include applying any order match predicates,
 		// connecting out to peers, and registering funding shim.
-		err = s.fundingManager.PrepChannelFunding(
+		err = s.server.fundingManager.PrepChannelFunding(
 			batch, nodeHasTorAddrs(nodeInfo.Uris), s.quit,
 		)
 		if err != nil {
@@ -436,7 +424,7 @@ func (s *rpcServer) handleServerMessage(rpcMsg *poolrpc.ServerAuctionMessage) er
 		// then start negotiating with the remote peers. We'll sign
 		// once all channel partners have responded.
 		batch := s.orderManager.PendingBatch()
-		channelKeys, err := s.fundingManager.BatchChannelSetup(
+		channelKeys, err := s.server.fundingManager.BatchChannelSetup(
 			batch, s.quit,
 		)
 		if err != nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -83,7 +83,7 @@ type accountStore struct {
 var _ account.Store = (*accountStore)(nil)
 
 func (s *accountStore) PendingBatch() error {
-	_, _, err := s.DB.PendingBatch()
+	_, err := s.DB.PendingBatchSnapshot()
 	return err
 }
 

--- a/server.go
+++ b/server.go
@@ -465,7 +465,7 @@ func (s *Server) setupClient() error {
 		MinBackoff:    s.cfg.MinBackoff,
 		MaxBackoff:    s.cfg.MaxBackoff,
 		BatchSource:   s.db,
-		BatchCleaner:  s.db,
+		BatchCleaner:  s.fundingManager,
 	}
 	s.AuctioneerClient, err = auctioneer.NewClient(clientCfg)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -465,6 +465,7 @@ func (s *Server) setupClient() error {
 		MinBackoff:    s.cfg.MinBackoff,
 		MaxBackoff:    s.cfg.MaxBackoff,
 		BatchSource:   s.db,
+		BatchCleaner:  s.db,
 	}
 	s.AuctioneerClient, err = auctioneer.NewClient(clientCfg)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/pool/auctioneer"
 	"github.com/lightninglabs/pool/clientdb"
+	"github.com/lightninglabs/pool/funding"
 	"github.com/lightninglabs/pool/order"
 	"github.com/lightninglabs/pool/poolrpc"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -67,6 +68,7 @@ type Server struct {
 
 	cfg             *Config
 	db              *clientdb.DB
+	fundingManager  *funding.Manager
 	lsatStore       *lsat.FileStore
 	lndServices     *lndclient.GrpcLndServices
 	lndClient       lnrpc.LightningClient
@@ -439,6 +441,19 @@ func (s *Server) setupClient() error {
 			),
 		),
 	)
+
+	// Create the funding manager.
+	s.fundingManager = &funding.Manager{
+		DB:               s.db,
+		WalletKit:        s.lndServices.WalletKit,
+		LightningClient:  s.lndServices.Client,
+		BaseClient:       s.lndClient,
+		BatchStepTimeout: funding.DefaultBatchStepTimeout,
+		NewNodesOnly:     s.cfg.NewNodesOnly,
+		PendingOpenChannels: make(
+			chan *lnrpc.ChannelEventUpdate_PendingOpenChannel,
+		),
+	}
 
 	// Create an instance of the auctioneer client library.
 	clientCfg := &auctioneer.Config{


### PR DESCRIPTION
Depends on #187, only the last 5 commits are new.

If a trader shuts down after being involved in a batch that resulted in a pending channel but is never finalized because other traders caused the batch to fail, they never get the chance to clean up those pending channels because the information necessary for that is only kept in memory.

We now also try to clean up pending channels and funding shims on startup if we detect an old, pending batch.
The big refactor in #187 was mainly necessary to do this in a clean way (concerning what component is responsible for what tasks).


For users with existing pending channels prior to this fix (they will never go away), we could add a manual `cleanup` command that:
* Gets all pending channels from `lnd` that have a thaw height
* Ask the auctioneer for all known batch transactions (easy once the cached batch query is in place)
* Abandon all pending channels that have a funding TXID that never made it into a batch.

But I think that should be done in an additional PR.
