### PR TITLE
account: use latest TX from DB instead of querying lnd

### DIFF
--- a/auctioneer/client.go
+++ b/auctioneer/client.go
@@ -1105,7 +1105,11 @@ func unmarshallServerRecoveredAccount(keyDesc *keychain.KeyDescriptor,
 		state = account.StateInitiated
 
 	case poolrpc.AuctionAccountState_STATE_CLOSED:
-		state = account.StatePendingClosed
+		// The auctioneer will keep the state as STATE_OPEN until the
+		// closing TX confirms on chain. Therefore if we get the
+		// STATE_CLOSED here it's already confirmed and we don't need to
+		// watch anything or try to re-publish the closing TX.
+		state = account.StateClosed
 
 	case poolrpc.AuctionAccountState_STATE_PENDING_UPDATE:
 		state = account.StatePendingUpdate


### PR DESCRIPTION
To make the account manager less dependent on the wallet state of lnd,
we use the latest TX state that we now store for the account instead of
the lnd ListTransactions RPC where possible.
This fixes account recovery for lnd nodes that were restored from the
seed and don't remember/detect all Pool transactions automatically.

This should fix the error `2020-12-24 14:46:33.574 [ERR] RPCS: error storing recovered account: account funding TX with output 002033ab6debxxxx not found` that was reported to me on Slack.
