### PR TITLE
rpc: delete previous pending batch after receiving replacement

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -377,6 +377,16 @@ func (s *rpcServer) handleServerMessage(rpcMsg *poolrpc.ServerAuctionMessage) er
 					"artifacts: %v", err)
 				return s.sendRejectBatch(batch, err)
 			}
+
+			// Clear our staging area for the new batch proposal. We
+			// consider any errors as a hard failure and reject the
+			// batch.
+			err = s.server.fundingManager.DeletePendingBatch()
+			if err != nil {
+				rpcLog.Errorf("Error clearing previous "+
+					"pending batch: %v", err)
+				return s.sendRejectBatch(batch, err)
+			}
 		}
 
 		// Do an in-depth verification of the batch.


### PR DESCRIPTION
This change was mostly motivated by the following scenario:

1. Trader accepts and signs a batch proposal, and stores it to disk.
2. Auctioneer send a new batch proposal due to another trader within the batch bailing out.
3. The trader who signed above rejects the new batch proposal.
4. The same trader attempts an account modification (deposit, withdrawal, renewal, etc.).
5. The spend handling logic as part of the account modification commits the staged batch proposal which was replaced, leaving the account state invalid.

This is addressed by removing the staged batch proposal upon any replacements, regardless of whether they are accepted or not. This change also falls in line with the existing work done to clear any artifacts as the result of a previously accepted batch proposal.