### PR TITLE
Add SOCKS proxy option

### DIFF
--- a/config.go
+++ b/config.go
@@ -101,6 +101,7 @@ type Config struct {
 	Insecure       bool   `long:"insecure" description:"disable tls"`
 	Network        string `long:"network" description:"network to run on" choice:"regtest" choice:"testnet" choice:"mainnet" choice:"simnet"`
 	AuctionServer  string `long:"auctionserver" description:"auction server address host:port"`
+	Proxy          string `long:"proxy" description:"The host:port of a SOCKS proxy through which all connections to the pool server will be established over"`
 	TLSPathAuctSrv string `long:"tlspathauctserver" description:"Path to auction server tls certificate"`
 	RPCListen      string `long:"rpclisten" description:"Address to listen on for gRPC clients"`
 	RESTListen     string `long:"restlisten" description:"Address to listen on for REST clients"`

--- a/server.go
+++ b/server.go
@@ -472,6 +472,7 @@ func (s *Server) setupClient() error {
 	// Create an instance of the auctioneer client library.
 	clientCfg := &auctioneer.Config{
 		ServerAddress: s.cfg.AuctionServer,
+		ProxyAddress:  s.cfg.Proxy,
 		Insecure:      s.cfg.Insecure,
 		TLSPathServer: s.cfg.TLSPathAuctSrv,
 		DialOpts:      s.cfg.AuctioneerDialOpts,


### PR DESCRIPTION
This PR adds a SOCKS proxy option to dial to the auction server via TOR.

I oriented myself on the loop implementation.

Runs well on my nix-bitcoin [branch](https://github.com/sputn1ck/nix-bitcoin/tree/lightning-pool-proxy)

fixes #215 