### PR TITLE
Provide default value for lnd macaroon path, fix shutdown panic in LiT

### DIFF
--- a/server.go
+++ b/server.go
@@ -510,7 +510,11 @@ func (s *Server) Stop() error {
 	if err != nil {
 		shutdownErr = err
 	}
-	s.grpcServer.GracefulStop()
+
+	// The gRPC server might be nil if started as a subserver.
+	if s.grpcServer != nil {
+		s.grpcServer.GracefulStop()
+	}
 
 	if s.restCancel != nil {
 		s.restCancel()

--- a/version.go
+++ b/version.go
@@ -29,7 +29,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 4
-	appPatch uint = 3
+	appPatch uint = 4
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
Fixes two issues I noticed when testing the latest version of Pool in combination with LiT.