### PR TITLE
GitHub: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: Bug
+assignees: ''
+
+---
+
+<!-- This issue tracker is only for technical issues related to Lightning Pool.
+
+General Lightning questions and/or support requests are best directed to the Lightning Community Slack https://lightning.engineering/slack.html.
+
+Also make sure you've read the Lightning Pool specific documentation at https://pool.lightning.engineering/.
+
+For reporting security issues, please read instructions at https://github.com/lightningnetwork/lnd#security.
+
+-->
+
+<!-- Describe the issue -->
+
+**Expected behavior**
+
+<!--- What behavior did you expect? -->
+
+**Actual behavior**
+
+<!--- What was the actual behavior (provide screenshots if the issue is UI related)? -->
+
+**To reproduce**
+
+<!--- How reliably can you reproduce the issue, what are the steps to do so? -->
+
+**System information**
+
+<!-- Are you using Lightning Pool as a standalone application or as part of Lightning Terminal? -->
+
+<!-- If you are using Lightning Pool as part of Lightning Terminal, did you install that using Umbrel? -->
+
+<!-- How are you interacting with Pool? Through the command line interface or the Lightning Terminal UI? -->
+
+<!-- What version of Lightning Pool are you using, where did you get it (website, self-compiled, etc)? -->
+
+<!-- What type of machine are you observing the error on (OS/CPU and disk type)? -->
+
+<!-- What is your operating system and its version? -->
+
+<!-- Any extra information that might be useful in the debugging process. -->
+<!--- This is normally the contents of a `pool.log` file. Raw text or a link to a pastebin type site are preferred. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation for Lightning Pool
+    url: https://pool.lightning.engineering/
+    about: Please make sure the Lightning Pool documentation cannot answer your question first.
+  - name: Documentation for lnd and related projects
+    url: https://docs.lightning.engineering/
+    about: Please make sure the general documentation cannot answer your question first.
+  - name: Lightning Community Slack
+    url: https://lightning.engineering/slack.html
+    about: Please ask and answer questions here.
+  - name: Security issue disclosure policy
+    url: https://github.com/lightningnetwork/lnd#security
+    about: Please refer to this document when reporting security related issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: Feature
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,16 @@
+---
+name: Other issue
+about: If you're not sure what issue type to pick
+title: ''
+labels: Other
+assignees: ''
+
+---
+
+<!-- This issue tracker is only for technical issues related to Lightning Pool.
+
+General Lightning questions and/or support requests are best directed to the Lightning Community Slack https://lightning.engineering/slack.html.
+
+Also make sure you've read the Lightning Pool specific documentation at https://pool.lightning.engineering/.
+
+-->


### PR DESCRIPTION
To make initial triage easier and nudge people into reading the
documentation and gathering information before submitting an issue, we
add three issue templates: bug reports, feature requests and "other".