### PR TITLE
poolrpc: fix command example that broke API docs

### DIFF
--- a/poolrpc/trader.proto
+++ b/poolrpc/trader.proto
@@ -168,7 +168,7 @@ service Trader {
     */
     rpc RegisterSidecar (RegisterSidecarRequest) returns (SidecarTicket);
 
-    /* pool: `sidecar expect-channel`
+    /* pool: `sidecar expectchannel`
     ExpectSidecarChannel is step 4/4 of the sidecar negotiation between the
     provider (the trader submitting the bid order) and the recipient (the trader
     receiving the sidecar channel).


### PR DESCRIPTION
The command example for the `sidecar expectchannel` was incorrect which
lead to the API docs generator erroring out.