### PR TITLE
rpcserver: fix Python gRPC client ALPN property error

### DIFF
--- a/config.go
+++ b/config.go
@@ -344,6 +344,7 @@ func getTLSConfig(cfg *Config) (*tls.Config, *credentials.TransportCredentials,
 	}
 
 	tlsCfg := cert.TLSConfFromCert(certData)
+	tlsCfg.NextProtos = []string{"h2"}
 	restCreds, err := credentials.NewClientTLSFromFile(
 		cfg.TLSCertPath, "",
 	)


### PR DESCRIPTION
There is an open issue for Python gRPC clients that is
currently being debugged https://github.com/grpc/grpc/issues/23172

It can be mitigated server-side by specifying h2 in the metadata header.

Tested on macOS and Linux. 

Unsure if this would have any negative side effects on other gRPC client langs.