### PR TITLE
poolrpc: namespace URI of LSAT REST call

### DIFF
--- a/poolrpc/rest-annotations.yaml
+++ b/poolrpc/rest-annotations.yaml
@@ -51,7 +51,7 @@ http:
     - selector: poolrpc.Trader.BatchSnapshot
       get: "/v1/pool/batch/snapshot"
     - selector: poolrpc.Trader.GetLsatTokens
-      get: "/v1/lsat/tokens"
+      get: "/v1/pool/lsat/tokens"
     - selector: poolrpc.Trader.Leases
       get: "/v1/pool/leases"
     - selector: poolrpc.Trader.NodeRatings


### PR DESCRIPTION
When trying to enable a single unified REST proxy in LiT, we noticed
that one URI collides between Loop and Pool (/v1/lsat/tokens).
We change the URI in Pool to fix the collision.

This is a potentially breaking change! Though we do not use REST in LiT
and are not aware of other projects using Pool's REST API yet so it
should impact a small number of users (or nobody really in the best
case).

Related: https://github.com/lightninglabs/lightning-terminal/pull/216