### PR TITLE
sidecar: on restart ensure recipient re-expects channel

### DIFF
--- a/auto_sidecar.go
+++ b/auto_sidecar.go
@@ -226,7 +226,7 @@ func (a *SidecarNegotiator) Stop() {
 }
 
 // TicketExecuted is a clean up function that should be called once the ticket
-// has been executeed, meaning a channel defined by it was confirmed ina batch
+// has been executed, meaning a channel defined by it was confirmed in a batch
 // on chain.
 func (a *SidecarNegotiator) TicketExecuted() {
 	select {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2458,6 +2458,11 @@ func (s *rpcServer) setTicketStateForOrder(newState sidecar.State,
 				"with ID %x to state %d: %v", ticket.ID[:],
 				newState, err)
 		}
+
+		// In addition to updating the ticket, we'll also signal to the
+		// acceptor that the channel that we were a provider of has
+		// been finalized so the state machine can terminate.
+		s.server.sidecarAcceptor.FinalizeTicket(ticket)
 	}
 
 	return nil

--- a/sidecar_acceptor_test.go
+++ b/sidecar_acceptor_test.go
@@ -457,6 +457,8 @@ func (s *sidecarTestCtx) assertRecipientExpectsChannel() {
 }
 
 func (s *sidecarTestCtx) assertRecipientTicketUpdated(expectedState sidecar.State) {
+	s.t.Helper()
+
 	select {
 	case stateUpdate := <-s.recipientDriver.stateUpdates:
 
@@ -638,6 +640,11 @@ func TestAutoSidecarNegotiation(t *testing.T) {
 	// sides should now be in a terminal state
 	testCtx.assertNoProviderMsgsRecvd()
 	testCtx.assertNoReceiverMsgsRecvd()
+
+	// The recipient of the ticket should re-expect the channel to
+	// re-register with the auctioneer to ensure the channel can be
+	// executed amidst their restarts.
+	testCtx.assertRecipientExpectsChannel()
 
 	// We'll now signal to both goroutines that the channel has been
 	// finalized, at this point, we expect both ticket to transition to the


### PR DESCRIPTION
Without this extra case on restart, the recipient would have an
unhandled state transition that would cause them to not expect the
channel as it should once the batch is finalized.