### PR TITLE
auctioneer+rpc: force a reconnection attempt on unknown error

### DIFF
--- a/auctioneer/client.go
+++ b/auctioneer/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -34,8 +35,7 @@ import (
 )
 
 const (
-	initialConnectRetries = 3
-	reconnectRetries      = 10
+	reconnectRetries = math.MaxInt16
 
 	// maxUnusedAccountKeyLookup is the number of successive account keys
 	// that we try and the server does not know of before aborting recovery.
@@ -542,7 +542,7 @@ func (c *Client) connectAndAuthenticate(ctx context.Context,
 	c.streamMutex.Unlock()
 
 	if needToConnect {
-		err := c.connectServerStream(0, initialConnectRetries)
+		err := c.connectServerStream(0, reconnectRetries)
 		if err != nil {
 			return sub, false, fmt.Errorf("connecting server "+
 				"stream failed: %v", err)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -258,6 +258,8 @@ func (s *rpcServer) serverHandler(blockChan chan int32, blockErrChan chan error)
 				}
 			}
 
+			rpcLog.Error("Unknown server error: %v", err)
+
 		case height := <-blockChan:
 			rpcLog.Infof("Received new block notification: height=%v",
 				height)


### PR DESCRIPTION
As is, we only attempt to reconnect if we receive a nice io.EOF error
from the gRPC client, which is usually triggered when the server
shutsdown. However in the wild, possibly due to a load balancer and/or
reverse proxy bug, we encounter another error which as is, doesn't
trigger the usual reconnection logic.

In this commit, we now log any unknown error, but then also attempt to
reconnect again by sending the normal "server shutdown" message.

As is, if this doesn't work after the max number of retries, we won't
retry any longer, but perhaps we should still attempt to retry in the
background.

// EDIT(guggero):

It turns out that on startup the auctioneer can get overwhelmed if
hundreds of traders try to authenticate all at once. So some of them run
into a timeout (which sounds like it's the trader's fault but the
timeout covers the whole 3-way handshake and is actually delayed by the
server, not the client) which wasn't handled correctly.

We now inspect the correct error if the authentication fails and try
reconnecting.