### PR TITLE
rpcserver: fix feeRate when using conf target

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -526,7 +526,8 @@ func (s *rpcServer) InitAccount(ctx context.Context,
 		value := btcutil.Amount(req.AccountValue)
 		confTarget := req.GetConfTarget()
 
-		feeRate, _, err := s.accountManager.QuoteAccount(
+		var err error
+		feeRate, _, err = s.accountManager.QuoteAccount(
 			ctx, value, confTarget,
 		)
 		if err != nil {


### PR DESCRIPTION
The `feeRate` variable was shadowing inside the `req.GetConfTarget() > 0`
switch case. The server was returning an error when the `feeRate` was
estimated using the confirmation target.


```
[ERR] RPCS: [/poolrpc.Trader/InitAccount]: fee rate of 0 sat/kw is too low, minimum is 253 sat/kw
```
