### PR TITLE
auctioneer: decrease the `reconnectRetries` value

### DIFF
--- a/auctioneer/client.go
+++ b/auctioneer/client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -35,7 +34,7 @@ import (
 )
 
 const (
-	reconnectRetries = math.MaxInt16
+	reconnectRetries = 90
 
 	// maxUnusedAccountKeyLookup is the number of successive account keys
 	// that we try and the server does not know of before aborting recovery.


### PR DESCRIPTION
Whenever the client is not able to connect to the server it waits some
backoff time and retries it. In some cases that fixes the the problem, for
example if the backend was down for some reason. However, if the client is
sending an invalid request again and again those retries will pollute
our server logs.

Set a more reasonable `reconnectRetries` value (90) so clients don't hang
sending invalid requests "forever" (65535)
