### PR TITLE
multi: update lndclient to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lightninglabs/aperture v0.1.6-beta
-	github.com/lightninglabs/lndclient v0.14.0-1
+	github.com/lightninglabs/lndclient v0.14.0-2
 	github.com/lightninglabs/pool/auctioneerrpc v1.0.3
 	github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display
 	github.com/lightningnetwork/lnd v0.13.0-beta.rc5.0.20211021015325-cac8da819ff9

--- a/go.sum
+++ b/go.sum
@@ -459,8 +459,8 @@ github.com/lightninglabs/aperture v0.1.6-beta/go.mod h1:9xl4mx778ZAzrB87nLHMqk+X
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
 github.com/lightninglabs/lndclient v0.11.0-4/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=
-github.com/lightninglabs/lndclient v0.14.0-1 h1:xFYwJqgN6mpl9RfdDh3wL4zTyvN209eTNyVXZA8+j7s=
-github.com/lightninglabs/lndclient v0.14.0-1/go.mod h1:MbVQTxIBNWMjnn8e6kBaEVVQsBjN1EEdpci3xaw2+rU=
+github.com/lightninglabs/lndclient v0.14.0-2 h1:zZSHZLcze9rB79F5KLsqP6KApQ2u5Xk3hkHyBVcXUQM=
+github.com/lightninglabs/lndclient v0.14.0-2/go.mod h1:MbVQTxIBNWMjnn8e6kBaEVVQsBjN1EEdpci3xaw2+rU=
 github.com/lightninglabs/neutrino v0.11.0/go.mod h1:CuhF0iuzg9Sp2HO6ZgXgayviFTn1QHdSTJlMncK80wg=
 github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200/go.mod h1:MlZmoKa7CJP3eR1s5yB7Rm5aSyadpKkxqAwLQmog7N0=
 github.com/lightninglabs/neutrino v0.12.1/go.mod h1:GlKninWpRBbL7b8G0oQ36/8downfnFwKsr0hbRA6E/E=

--- a/internal/test/walletkit_mock.go
+++ b/internal/test/walletkit_mock.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
@@ -159,4 +160,13 @@ func (m *MockWalletKit) BumpFee(context.Context, wire.OutPoint,
 	chainfee.SatPerKWeight) error {
 
 	panic("unimplemented")
+}
+
+// ListAccounts retrieves all accounts belonging to the wallet by default.
+// Optional name and addressType can be provided to filter through all of the
+// wallet accounts and return only those matching.
+func (m *MockWalletKit) ListAccounts(context.Context, string,
+	walletrpc.AddressType) ([]*walletrpc.Account, error) {
+
+	return nil, nil
 }

--- a/server.go
+++ b/server.go
@@ -133,8 +133,8 @@ func (s *Server) Start() error {
 	// what we need
 	s.lndClient, err = lndclient.NewBasicClient(
 		s.cfg.Lnd.Host, s.cfg.Lnd.TLSPath,
-		path.Dir(s.cfg.Lnd.MacaroonPath), "", "", s.cfg.Network, false,
-		false, lndclient.MacFilename(path.Base(s.cfg.Lnd.MacaroonPath)),
+		path.Dir(s.cfg.Lnd.MacaroonPath), s.cfg.Network,
+		lndclient.MacFilename(path.Base(s.cfg.Lnd.MacaroonPath)),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
With this commit we update to the latest lndclient version of the 0.14.0
branch that reverts a breaking change in the basic client and also fixes
a "close of closed channel" panic.

#### Pull Request Checklist
- [ ] LndServices minimum version has been updated if new lnd apis/fields are
  used.
