### PR TITLE
macaroons+server: close macaroon DB on server shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lightninglabs/pool/order"
 	"github.com/lightninglabs/pool/poolrpc"
 	"github.com/lightninglabs/pool/terms"
+	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
@@ -82,6 +83,7 @@ type Server struct {
 	grpcListener    net.Listener
 	restListener    net.Listener
 	restCancel      func()
+	macaroonDB      kvdb.Backend
 	macaroonService *macaroons.Service
 	wg              sync.WaitGroup
 }
@@ -581,7 +583,7 @@ func (s *Server) Stop() error {
 	if err := s.db.Close(); err != nil {
 		log.Errorf("Error closing DB: %v", err)
 	}
-	if err := s.macaroonService.Close(); err != nil {
+	if err := s.stopMacaroonService(); err != nil {
 		log.Errorf("Error stopping macaroon service: %v", err)
 	}
 	s.lndServices.Close()


### PR DESCRIPTION
In the integration tests we stop the pool daemon but don't exit the main
process. So it can happen that the underlying bbolt DB isn't properly
closed and when the daemon is started again during the test it runs into
a timeout. We fix this by properly closing the DB when the service is
stopped.

The macaroon service doesn't close the backend anymore because in the
lnd context the backend connection could be a shared connection to a
remote DB that we don't want to close when we start/stop the service
itself.

#### Pull Request Checklist
- [ ] LndServices minimum version has been updated if new lnd apis/fields are
  used.
