### PR TITLE
pool: conditionally create default macaroon file

### DIFF
--- a/macaroons.go
+++ b/macaroons.go
@@ -193,7 +193,7 @@ var (
 // unlocks the macaroon database and creates the default macaroon if it doesn't
 // exist yet. If macaroons are disabled in general in the configuration, none of
 // these actions are taken.
-func (s *Server) startMacaroonService() error {
+func (s *Server) startMacaroonService(createDefaultMacaroonFile bool) error {
 	var err error
 	s.macaroonDB, err = kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
 		DBPath:     s.cfg.BaseDir,
@@ -227,8 +227,11 @@ func (s *Server) startMacaroonService() error {
 		return fmt.Errorf("unable to unlock macaroon DB: %v", err)
 	}
 
-	// Create macaroon files for pool CLI to use if they don't exist.
-	if !lnrpc.FileExists(s.cfg.MacaroonPath) {
+	// There are situations in which we don't want a macaroon to be created
+	// on disk (for example when running inside LiT stateless integrated
+	// mode). For any other cases, we create macaroon files for the pool CLI
+	// in the default directory.
+	if createDefaultMacaroonFile && !lnrpc.FileExists(s.cfg.MacaroonPath) {
 		// We don't offer the ability to rotate macaroon root keys yet,
 		// so just use the default one since the service expects some
 		// value to be set.

--- a/server.go
+++ b/server.go
@@ -144,7 +144,7 @@ func (s *Server) Start() error {
 
 	// Start the macaroon service and let it create its default macaroon in
 	// case it doesn't exist yet.
-	if err := s.startMacaroonService(); err != nil {
+	if err := s.startMacaroonService(true); err != nil {
 		return err
 	}
 	shutdownFuncs["macaroon"] = s.stopMacaroonService
@@ -310,7 +310,8 @@ func (s *Server) Start() error {
 // StartAsSubserver is an alternative start method where the RPC server does not
 // create its own gRPC server but registers on an existing one.
 func (s *Server) StartAsSubserver(lndClient lnrpc.LightningClient,
-	lndGrpc *lndclient.GrpcLndServices) error {
+	lndGrpc *lndclient.GrpcLndServices,
+	createDefaultMacaroonFile bool) error {
 
 	if atomic.AddInt32(&s.started, 1) != 1 {
 		return fmt.Errorf("trader can only be started once")
@@ -337,7 +338,7 @@ func (s *Server) StartAsSubserver(lndClient lnrpc.LightningClient,
 
 	// Start the macaroon service and let it create its default macaroon in
 	// case it doesn't exist yet.
-	if err := s.startMacaroonService(); err != nil {
+	if err := s.startMacaroonService(createDefaultMacaroonFile); err != nil {
 		return err
 	}
 	shutdownFuncs["macaroon"] = s.stopMacaroonService


### PR DESCRIPTION
In some cases we don't want the default macaroon file to be created on
disk, so we allow passing in a boolean that toggles the macaroon
creation.

This is for the LiT stateless integrated mode.

#### Pull Request Checklist
- [X] LndServices minimum version has been updated if new lnd apis/fields are
  used.
