### PR TITLE
multi: remove static default channel types instead select them based on lnd's verison

### DIFF
--- a/cmd/pool/order.go
+++ b/cmd/pool/order.go
@@ -115,10 +115,6 @@ var sharedFlags = []cli.Flag{
 			"order being matched (%q, %q)",
 			channelTypePeerDependent,
 			channelTypeScriptEnforced),
-		// TODO: Switch to script enforcement by default once we can
-		// enforce the lnd release supporting script enforced channels
-		// as the minimalCompatibleVersion.
-		Value: channelTypePeerDependent,
 	},
 }
 
@@ -248,6 +244,8 @@ func parseCommonParams(ctx *cli.Context, blockDuration uint32) (*poolrpc.Order, 
 	// order match.
 	channelType := ctx.String("channel_type")
 	switch channelType {
+	// No values means that the unknown type will be set, which means the
+	// sever will select a type based on the version of the connected node.
 	case "":
 		break
 	case channelTypePeerDependent:

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lightninglabs/aperture v0.1.6-beta
-	github.com/lightninglabs/lndclient v0.14.0-5
+	github.com/lightninglabs/lndclient v0.14.0-7
 	github.com/lightninglabs/pool/auctioneerrpc v1.0.5
 	github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display
 	github.com/lightningnetwork/lnd v0.14.1-beta

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,8 @@ github.com/lightninglabs/aperture v0.1.6-beta/go.mod h1:9xl4mx778ZAzrB87nLHMqk+X
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
 github.com/lightninglabs/lndclient v0.11.0-4/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=
-github.com/lightninglabs/lndclient v0.14.0-5 h1:dI2/Y2fn9m5VuwMTd/DcF6y0DYdMy3pk0MPu4xNjj54=
-github.com/lightninglabs/lndclient v0.14.0-5/go.mod h1:2kH9vNoc29ghIkfMjxwSeK8yCxsYfR80XAJ9PU/QWWk=
+github.com/lightninglabs/lndclient v0.14.0-7 h1:muqPju9ixBtQNcO0SkvbZ2b2oORUMRqQ4e+aC077Qa8=
+github.com/lightninglabs/lndclient v0.14.0-7/go.mod h1:2kH9vNoc29ghIkfMjxwSeK8yCxsYfR80XAJ9PU/QWWk=
 github.com/lightninglabs/neutrino v0.11.0/go.mod h1:CuhF0iuzg9Sp2HO6ZgXgayviFTn1QHdSTJlMncK80wg=
 github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200/go.mod h1:MlZmoKa7CJP3eR1s5yB7Rm5aSyadpKkxqAwLQmog7N0=
 github.com/lightninglabs/neutrino v0.12.1/go.mod h1:GlKninWpRBbL7b8G0oQ36/8downfnFwKsr0hbRA6E/E=

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1191,12 +1191,30 @@ func prepareAndSubmitOrder(ctx context.Context, o order.Order,
 func (s *rpcServer) SubmitOrder(ctx context.Context,
 	req *poolrpc.SubmitOrderRequest) (*poolrpc.SubmitOrderResponse, error) {
 
+	// We'll use this channel type selector to pick a channel type based on
+	// the current connected lnd version. This lets us graceful update to
+	// new features as they're available, while still supporting older
+	// versions of lnd.
+	chanTypeSelector := order.WithDefaultChannelType(func() order.ChannelType {
+		// If they didn't specify a value, then we'll select one based
+		// on the version of lnd we detect.
+		verErr := lndclient.AssertVersionCompatible(
+			s.server.lndVersion, scriptEnforceVersion,
+		)
+		if verErr == nil {
+			return order.ChannelTypeScriptEnforced
+		}
+
+		return order.ChannelTypePeerDependent
+	})
+
 	var o order.Order
 	switch requestOrder := req.Details.(type) {
 	case *poolrpc.SubmitOrderRequest_Ask:
 		a := requestOrder.Ask
 		kit, err := order.ParseRPCOrder(
 			a.Version, a.LeaseDurationBlocks, a.Details,
+			chanTypeSelector,
 		)
 		if err != nil {
 			return nil, err
@@ -1210,6 +1228,7 @@ func (s *rpcServer) SubmitOrder(ctx context.Context,
 		b := requestOrder.Bid
 		kit, err := order.ParseRPCOrder(
 			b.Version, b.LeaseDurationBlocks, b.Details,
+			chanTypeSelector,
 		)
 		if err != nil {
 			return nil, err

--- a/server.go
+++ b/server.go
@@ -52,6 +52,18 @@ var (
 			"signrpc", "walletrpc", "chainrpc", "invoicesrpc",
 		},
 	}
+
+	// scriptEnforceVersion is the version of lnd that enabled lease duration script
+	// enforcement as a new channel type. We'll use this to decide what
+	// order type to default to.
+	scriptEnforceVersion = &verrpc.Version{
+		AppMajor: 0,
+		AppMinor: 14,
+		AppPatch: 0,
+		BuildTags: []string{
+			"signrpc", "walletrpc", "chainrpc", "invoicesrpc",
+		},
+	}
 )
 
 // Server is the main poold trader server.
@@ -70,6 +82,8 @@ type Server struct {
 	// GetIdentity returns the current LSAT identification of the trader
 	// client or an error if none has been established yet.
 	GetIdentity func() (*lsat.TokenID, error)
+
+	lndVersion *verrpc.Version
 
 	cfg             *Config
 	db              *clientdb.DB
@@ -127,6 +141,11 @@ func (s *Server) Start() error {
 		s.lndServices.Close()
 		return nil
 	}
+
+	// Now that we have lnd, lets extract the current version so we can use
+	// this to gate features that we'll use based on the functionality
+	// available.
+	s.lndVersion = s.lndServices.Version
 
 	// As there're some other lower-level operations we may need access to,
 	// we'll also make a connection for a "basic client".


### PR DESCRIPTION
In this PR, we remove the defaults and the CLI and RPC level. We replace them with a new set of functional options that'll let us decide dynamically which features to use based on the lnd version. This lets us support older versions, while being able to activated newer features as we detect them based on what lnd offers. 

#### Pull Request Checklist
- [x] LndServices minimum version has been updated if new lnd apis/fields are
  used.
