### PR TITLE
Conditional batch version for itests

### DIFF
--- a/auctioneer/account_subscription.go
+++ b/auctioneer/account_subscription.go
@@ -16,13 +16,14 @@ import (
 // auction. It can also perform the 3-way authentication handshake that is
 // needed to authenticate a trader for a subscription.
 type acctSubscription struct {
-	acctKey    *keychain.KeyDescriptor
-	commitHash [32]byte
-	sendMsg    func(*auctioneerrpc.ClientAuctionMessage) error
-	signer     lndclient.SignerClient
-	msgChan    chan *auctioneerrpc.ServerAuctionMessage
-	errChan    chan error
-	quit       chan struct{}
+	acctKey      *keychain.KeyDescriptor
+	commitHash   [32]byte
+	sendMsg      func(*auctioneerrpc.ClientAuctionMessage) error
+	signer       lndclient.SignerClient
+	msgChan      chan *auctioneerrpc.ServerAuctionMessage
+	batchVersion order.BatchVersion
+	errChan      chan error
+	quit         chan struct{}
 }
 
 // authenticate performs the 3-way authentication handshake between the trader
@@ -50,7 +51,7 @@ func (s *acctSubscription) authenticate(ctx context.Context) error {
 		Msg: &auctioneerrpc.ClientAuctionMessage_Commit{
 			Commit: &auctioneerrpc.AccountCommitment{
 				CommitHash:   s.commitHash[:],
-				BatchVersion: uint32(order.CurrentBatchVersion),
+				BatchVersion: uint32(s.batchVersion),
 			},
 		},
 	})

--- a/auctioneer/account_subscription_test.go
+++ b/auctioneer/account_subscription_test.go
@@ -45,7 +45,7 @@ func TestAccountSubscriptionAuthenticate(t *testing.T) {
 			sendMsg:      sendMsg,
 			signer:       testSigner,
 			msgChan:      srvMsgChan,
-			batchVersion: order.CurrentBatchVersion,
+			batchVersion: order.LatestBatchVersion,
 		}
 	)
 
@@ -108,7 +108,7 @@ func TestAccountSubscriptionAuthenticateAbort(t *testing.T) {
 			sendMsg:      sendMsg,
 			signer:       testSigner,
 			msgChan:      srvMsgChan,
-			batchVersion: order.CurrentBatchVersion,
+			batchVersion: order.LatestBatchVersion,
 		}
 	)
 
@@ -161,7 +161,7 @@ func TestAccountSubscriptionAuthenticateContextClose(t *testing.T) {
 			sendMsg:      sendMsg,
 			signer:       testSigner,
 			msgChan:      srvMsgChan,
-			batchVersion: order.CurrentBatchVersion,
+			batchVersion: order.LatestBatchVersion,
 		}
 		ctxc, cancel = context.WithCancel(context.Background())
 	)
@@ -216,7 +216,7 @@ func TestAccountSubscriptionAuthenticateError(t *testing.T) {
 			sendMsg:      sendMsg,
 			signer:       testSigner,
 			msgChan:      srvMsgChan,
-			batchVersion: order.CurrentBatchVersion,
+			batchVersion: order.LatestBatchVersion,
 			errChan:      make(chan error),
 		}
 	)

--- a/auctioneer/account_subscription_test.go
+++ b/auctioneer/account_subscription_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/lightninglabs/pool/auctioneerrpc"
 	"github.com/lightninglabs/pool/internal/test"
+	"github.com/lightninglabs/pool/order"
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
@@ -40,10 +41,11 @@ func TestAccountSubscriptionAuthenticate(t *testing.T) {
 			return nil
 		}
 		sub = &acctSubscription{
-			acctKey: testAccountDesc,
-			sendMsg: sendMsg,
-			signer:  testSigner,
-			msgChan: srvMsgChan,
+			acctKey:      testAccountDesc,
+			sendMsg:      sendMsg,
+			signer:       testSigner,
+			msgChan:      srvMsgChan,
+			batchVersion: order.CurrentBatchVersion,
 		}
 	)
 
@@ -102,10 +104,11 @@ func TestAccountSubscriptionAuthenticateAbort(t *testing.T) {
 			return nil
 		}
 		sub = &acctSubscription{
-			acctKey: testAccountDesc,
-			sendMsg: sendMsg,
-			signer:  testSigner,
-			msgChan: srvMsgChan,
+			acctKey:      testAccountDesc,
+			sendMsg:      sendMsg,
+			signer:       testSigner,
+			msgChan:      srvMsgChan,
+			batchVersion: order.CurrentBatchVersion,
 		}
 	)
 
@@ -154,10 +157,11 @@ func TestAccountSubscriptionAuthenticateContextClose(t *testing.T) {
 			return nil
 		}
 		sub = &acctSubscription{
-			acctKey: testAccountDesc,
-			sendMsg: sendMsg,
-			signer:  testSigner,
-			msgChan: srvMsgChan,
+			acctKey:      testAccountDesc,
+			sendMsg:      sendMsg,
+			signer:       testSigner,
+			msgChan:      srvMsgChan,
+			batchVersion: order.CurrentBatchVersion,
 		}
 		ctxc, cancel = context.WithCancel(context.Background())
 	)
@@ -208,11 +212,12 @@ func TestAccountSubscriptionAuthenticateError(t *testing.T) {
 			return nil
 		}
 		sub = &acctSubscription{
-			acctKey: testAccountDesc,
-			sendMsg: sendMsg,
-			signer:  testSigner,
-			msgChan: srvMsgChan,
-			errChan: make(chan error),
+			acctKey:      testAccountDesc,
+			sendMsg:      sendMsg,
+			signer:       testSigner,
+			msgChan:      srvMsgChan,
+			batchVersion: order.CurrentBatchVersion,
+			errChan:      make(chan error),
 		}
 	)
 

--- a/auctioneer/client.go
+++ b/auctioneer/client.go
@@ -105,6 +105,10 @@ type Config struct {
 	// trader's pending batch.
 	BatchCleaner BatchCleaner
 
+	// BatchVersion is the batch version that we should use when
+	// authenticating with the auction server.
+	BatchVersion order.BatchVersion
+
 	// GenUserAgent is a function that generates a complete user agent
 	// string given the incoming request context.
 	GenUserAgent func(context.Context) string
@@ -581,12 +585,13 @@ func (c *Client) connectAndAuthenticate(ctx context.Context,
 	// Before we can expect to receive any updates, we need to perform the
 	// 3-way authentication handshake.
 	sub = &acctSubscription{
-		acctKey: acctKey,
-		sendMsg: c.SendAuctionMessage,
-		signer:  c.cfg.Signer,
-		msgChan: make(chan *auctioneerrpc.ServerAuctionMessage),
-		errChan: tempErrChan,
-		quit:    make(chan struct{}),
+		acctKey:      acctKey,
+		sendMsg:      c.SendAuctionMessage,
+		signer:       c.cfg.Signer,
+		msgChan:      make(chan *auctioneerrpc.ServerAuctionMessage),
+		batchVersion: c.cfg.BatchVersion,
+		errChan:      tempErrChan,
+		quit:         make(chan struct{}),
 	}
 	c.subscribedAcctsMtx.Lock()
 	c.subscribedAccts[acctPubKey] = sub

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/pool/order"
 	"github.com/lightningnetwork/lnd/cert"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -160,6 +161,15 @@ type Config struct {
 	// AuctioneerDialOpts is a list of dial options that should be used when
 	// dialing the auctioneer server.
 	AuctioneerDialOpts []grpc.DialOption
+
+	// DebugConfig is a set of debug options used for development and
+	// testing only.
+	DebugConfig *DebugConfig `group:"debug" namespace:"debug" hidden:"true"`
+}
+
+// DebugConfig is a set of debug options used for development and testing only.
+type DebugConfig struct {
+	BatchVersion uint32 `long:"batchversion" description:"The batch version to use -- NOTE: for testing purposes only, don't use on mainnet"`
 }
 
 const (
@@ -194,6 +204,9 @@ func DefaultConfig() Config {
 		Lnd: &LndConfig{
 			Host:         "localhost:10009",
 			MacaroonPath: DefaultLndMacaroonPath,
+		},
+		DebugConfig: &DebugConfig{
+			BatchVersion: uint32(order.ExtendAccountBatchVersion),
 		},
 	}
 }

--- a/order/batch.go
+++ b/order/batch.go
@@ -53,10 +53,8 @@ const (
 )
 
 const (
-
-	// CurrentBatchVersion points to the version used by the client for
-	// verifying a batch.
-	CurrentBatchVersion = ExtendAccountBatchVersion
+	// LatestBatchVersion points to the most recent batch version.
+	LatestBatchVersion = ExtendAccountBatchVersion
 
 	// LegacyLeaseDurationBucket is the single static duration bucket that
 	// was used for orders before dynamic duration buckets were added.

--- a/order/batch_verifier.go
+++ b/order/batch_verifier.go
@@ -75,13 +75,12 @@ type batchVerifier struct {
 //
 // NOTE: This method is part of the BatchVerifier interface.
 func (v *batchVerifier) Verify(batch *Batch, bestHeight uint32) error {
-
-	// First of all, make sure the server used the same batch version
-	// than we use for creating the batch. Otherwise we bail out of the batch.
-	// This should already be handled when the client connects/authenticates.
-	// But doesn't hurt to check again.
+	// First, make sure the server used the same batch version than we use
+	// for creating the batch. Otherwise, we bail out of the batch.
+	// This should already be handled when the client connects/
+	// authenticates. But doesn't hurt to check again.
 	if batch.Version != v.version {
-		return ErrVersionMismatch
+		return NewErrVersionMismatch(v.version, batch.Version)
 	}
 
 	// Reject the batch if we're too far in the past or future compared to

--- a/order/batch_verifier_test.go
+++ b/order/batch_verifier_test.go
@@ -61,7 +61,9 @@ func TestBatchVerifier(t *testing.T) {
 		{
 			name:         "version mismatch",
 			batchVersion: DefaultBatchVersion,
-			expectedErr:  ErrVersionMismatch.Error(),
+			expectedErr: NewErrVersionMismatch(
+				DefaultBatchVersion, 999,
+			).Error(),
 			doVerify: func(v BatchVerifier, a *Ask, b1, b2 *Bid,
 				b *Batch) error {
 

--- a/order/manager.go
+++ b/order/manager.go
@@ -32,22 +32,35 @@ const (
 )
 
 var (
-	// ErrVersionMismatch is the error that is returned if we don't
-	// implement the same batch verification version as the server.
-	ErrVersionMismatch = fmt.Errorf("version %d mismatches server version",
-		CurrentBatchVersion)
-
-	// ErrUnsupportedVersion is the error that is returned if the server
-	// doesn't support the our batch verification version.
-	ErrUnsupportedVersion = fmt.Errorf("version %d is not supported by "+
-		"the server", CurrentBatchVersion)
-
 	// ErrInvalidBatchHeightHint is an error returned by a trader upon
 	// verifying a batch when its proposed height hint is outside of the
 	// trader's acceptable range.
 	ErrInvalidBatchHeightHint = errors.New("proposed batch height hint is " +
 		"outside of acceptable range")
 )
+
+// ErrVersionMismatch is the error that is returned if we don't implement the
+// same batch verification version as the server.
+type ErrVersionMismatch struct {
+	clientVersion BatchVersion
+	serverVersion BatchVersion
+}
+
+// NewErrVersionMismatch returns a new error.
+func NewErrVersionMismatch(clientVersion,
+	serverVersion BatchVersion) *ErrVersionMismatch {
+
+	return &ErrVersionMismatch{
+		clientVersion: clientVersion,
+		serverVersion: serverVersion,
+	}
+}
+
+// Error returns the underlying error message.
+func (e *ErrVersionMismatch) Error() string {
+	return fmt.Sprintf("version %d mismatches server version %d",
+		e.clientVersion, e.serverVersion)
+}
 
 // ManagerConfig contains all of the required dependencies for the Manager to
 // carry out its duties.

--- a/order/manager.go
+++ b/order/manager.go
@@ -79,6 +79,10 @@ type ManagerConfig struct {
 
 	// Signer is used to sign orders before submitting them to the server.
 	Signer lndclient.SignerClient
+
+	// BatchVersion is the batch version that we should use to verify new
+	// batches against.
+	BatchVersion BatchVersion
 }
 
 // manager is responsible for the management of orders.
@@ -138,7 +142,7 @@ func (m *manager) Start() error {
 			getAccount:    m.cfg.AcctStore.Account,
 			wallet:        m.cfg.Wallet,
 			ourNodePubkey: m.ourNodeInfo.IdentityPubkey,
-			version:       CurrentBatchVersion,
+			version:       m.cfg.BatchVersion,
 		}
 		m.batchSigner = &batchSigner{
 			getAccount: m.cfg.AcctStore.Account,

--- a/order/manager_test.go
+++ b/order/manager_test.go
@@ -25,7 +25,7 @@ func TestValidateOrderAccountIsolation(t *testing.T) {
 	orderStore := newMockStore()
 	orderManager := NewManager(&ManagerConfig{
 		Store:        orderStore,
-		BatchVersion: CurrentBatchVersion,
+		BatchVersion: LatestBatchVersion,
 	})
 
 	// We'll now create two accounts, one that's 1 BTC in size, while the
@@ -111,7 +111,7 @@ func TestValidateOrder(t *testing.T) {
 	orderStore := newMockStore()
 	orderManager := NewManager(&ManagerConfig{
 		Store:        orderStore,
-		BatchVersion: CurrentBatchVersion,
+		BatchVersion: LatestBatchVersion,
 	})
 
 	// We'll now create an account with sufficient size.
@@ -272,7 +272,7 @@ func TestPrepareOrderSidecarTicket(t *testing.T) {
 		Wallet:       test.NewMockWalletKit(),
 		Lightning:    mockLightning,
 		Signer:       mockSigner,
-		BatchVersion: CurrentBatchVersion,
+		BatchVersion: LatestBatchVersion,
 	})
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()

--- a/order/manager_test.go
+++ b/order/manager_test.go
@@ -24,7 +24,8 @@ func TestValidateOrderAccountIsolation(t *testing.T) {
 
 	orderStore := newMockStore()
 	orderManager := NewManager(&ManagerConfig{
-		Store: orderStore,
+		Store:        orderStore,
+		BatchVersion: CurrentBatchVersion,
 	})
 
 	// We'll now create two accounts, one that's 1 BTC in size, while the
@@ -109,7 +110,8 @@ func TestValidateOrder(t *testing.T) {
 
 	orderStore := newMockStore()
 	orderManager := NewManager(&ManagerConfig{
-		Store: orderStore,
+		Store:        orderStore,
+		BatchVersion: CurrentBatchVersion,
 	})
 
 	// We'll now create an account with sufficient size.
@@ -266,10 +268,11 @@ func TestPrepareOrderSidecarTicket(t *testing.T) {
 	mockLightning := test.NewMockLightning()
 	mockSigner := test.NewMockSigner()
 	mgr := NewManager(&ManagerConfig{
-		AcctStore: &mockAccountStore{},
-		Wallet:    test.NewMockWalletKit(),
-		Lightning: mockLightning,
-		Signer:    mockSigner,
+		AcctStore:    &mockAccountStore{},
+		Wallet:       test.NewMockWalletKit(),
+		Lightning:    mockLightning,
+		Signer:       mockSigner,
+		BatchVersion: CurrentBatchVersion,
 	})
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1585,9 +1585,12 @@ func (s *rpcServer) sendRejectBatch(batch *order.Batch, failure error) error {
 	}
 
 	// Attach the status code to the message to give a bit more context.
-	var partialReject *funding.MatchRejectErr
+	var (
+		partialReject   *funding.MatchRejectErr
+		versionMismatch *order.ErrVersionMismatch
+	)
 	switch {
-	case errors.Is(failure, order.ErrVersionMismatch):
+	case errors.As(failure, &versionMismatch):
 		msg.Reject.ReasonCode = auctioneerrpc.OrderMatchReject_BATCH_VERSION_MISMATCH
 
 		// Track this reject by adding an event to our orders.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -117,6 +117,9 @@ func newRPCServer(server *Server) *rpcServer {
 			Lightning: lndServices.Client,
 			Wallet:    lndServices.WalletKit,
 			Signer:    lndServices.Signer,
+			BatchVersion: order.BatchVersion(
+				server.cfg.DebugConfig.BatchVersion,
+			),
 		}),
 		marshaler: NewMarshaler(&marshalerConfig{
 			GetOrders: server.db.GetOrders,

--- a/server.go
+++ b/server.go
@@ -505,6 +505,9 @@ func (s *Server) setupClient() error {
 		MaxBackoff:    s.cfg.MaxBackoff,
 		BatchSource:   s.db,
 		BatchCleaner:  s.fundingManager,
+		BatchVersion: order.BatchVersion(
+			s.cfg.DebugConfig.BatchVersion,
+		),
 		GenUserAgent: func(ctx context.Context) string {
 			return UserAgent(InitiatorFromContext(ctx))
 		},


### PR DESCRIPTION
Makes the batch version configurable to enable integration testing of different client batch versions in the same batch.

#### Pull Request Checklist
- [ ] LndServices minimum version has been updated if new lnd apis/fields are
  used.
