### PR TITLE
Pool 0.5.4

### DIFF
--- a/order/batch_storer.go
+++ b/order/batch_storer.go
@@ -99,6 +99,17 @@ func (s *batchStorer) StorePendingBatch(batch *Batch) error {
 				account.IncrementBatchKey(),
 			)
 
+			// The account expiry needs to be updated only when the
+			// client supports it.
+			if batch.Version.SupportsAccountExtension() &&
+				diff.NewExpiry != 0 {
+
+				modifiers = append(
+					modifiers,
+					account.ExpiryModifier(diff.NewExpiry),
+				)
+			}
+
 		// The account was fully spent on-chain. We need to wait for the
 		// batch (spend) TX to be confirmed still.
 		case auctioneerrpc.AccountDiff_OUTPUT_FULLY_SPENT,
@@ -126,16 +137,6 @@ func (s *batchStorer) StorePendingBatch(batch *Batch) error {
 		modifiers = append(
 			modifiers, account.LatestTxModifier(batch.BatchTX),
 		)
-
-		// The account expiry needs to be updated only when the client
-		// supports it.
-		if batch.Version.SupportsAccountExtension() &&
-			diff.NewExpiry != 0 {
-
-			modifiers = append(
-				modifiers, account.ExpiryModifier(diff.NewExpiry),
-			)
-		}
 
 		accountModifiers[idx] = modifiers
 	}

--- a/order/rpc_parse.go
+++ b/order/rpc_parse.go
@@ -19,9 +19,9 @@ import (
 	"github.com/lightningnetwork/lnd/tor"
 )
 
-// OrderParseOption defines a set of functional param options that can be used
+// ParseOption defines a set of functional param options that can be used
 // to modify our we parse orders based on some optional directives.
-type OrderParseOption func(*parseOptions)
+type ParseOption func(*parseOptions)
 
 // parseOptions houses the set of functional options used to parse RPC orders.
 type parseOptions struct {
@@ -34,7 +34,7 @@ type ChanTypeSelector func() ChannelType
 
 // WithDefaultChannelType allows a caller to select a default channel type
 // based on the version of the lnd node attempting to create the order.
-func WithDefaultChannelType(selector ChanTypeSelector) OrderParseOption {
+func WithDefaultChannelType(selector ChanTypeSelector) ParseOption {
 	return func(o *parseOptions) {
 		o.chanTypeSelector = selector
 	}
@@ -48,7 +48,7 @@ func defaultParseOptions() *parseOptions {
 // ParseRPCOrder parses the incoming raw RPC order into the go native data
 // types used in the order struct.
 func ParseRPCOrder(version, leaseDuration uint32,
-	details *poolrpc.Order, parseOpts ...OrderParseOption) (*Kit, error) {
+	details *poolrpc.Order, parseOpts ...ParseOption) (*Kit, error) {
 
 	opts := defaultParseOptions()
 	for _, newOpt := range parseOpts {

--- a/version.go
+++ b/version.go
@@ -29,7 +29,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 5
-	appPatch uint = 3
+	appPatch uint = 4
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
Prepare for new client release by bumping the version (and fixing a linter issue left over from #330).

#### Pull Request Checklist
- [ ] LndServices minimum version has been updated if new lnd apis/fields are
  used.
