### PR TITLE
multi: use lndclient MacaroonService

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,11 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lightninglabs/aperture v0.1.6-beta
-	github.com/lightninglabs/lndclient v0.14.0-7
+	github.com/lightninglabs/lndclient v0.14.0-8
 	github.com/lightninglabs/pool/auctioneerrpc v1.0.5
 	github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display
 	github.com/lightningnetwork/lnd v0.14.1-beta
 	github.com/lightningnetwork/lnd/cert v1.1.0
-	github.com/lightningnetwork/lnd/kvdb v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.20.0
 	go.etcd.io/bbolt v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,8 @@ github.com/lightninglabs/aperture v0.1.6-beta/go.mod h1:9xl4mx778ZAzrB87nLHMqk+X
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
 github.com/lightninglabs/lndclient v0.11.0-4/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=
-github.com/lightninglabs/lndclient v0.14.0-7 h1:muqPju9ixBtQNcO0SkvbZ2b2oORUMRqQ4e+aC077Qa8=
-github.com/lightninglabs/lndclient v0.14.0-7/go.mod h1:2kH9vNoc29ghIkfMjxwSeK8yCxsYfR80XAJ9PU/QWWk=
+github.com/lightninglabs/lndclient v0.14.0-8 h1:vdwV6yFU4A7BjG2V8cpI8Kqdl2M0NSfsA+RWR+JGTko=
+github.com/lightninglabs/lndclient v0.14.0-8/go.mod h1:YIE/Yac69hIMiq9cm/ZC2sP4F0Llv3tC4hZGfgOhdeY=
 github.com/lightninglabs/neutrino v0.11.0/go.mod h1:CuhF0iuzg9Sp2HO6ZgXgayviFTn1QHdSTJlMncK80wg=
 github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200/go.mod h1:MlZmoKa7CJP3eR1s5yB7Rm5aSyadpKkxqAwLQmog7N0=
 github.com/lightninglabs/neutrino v0.12.1/go.mod h1:GlKninWpRBbL7b8G0oQ36/8downfnFwKsr0hbRA6E/E=

--- a/macaroons.go
+++ b/macaroons.go
@@ -1,18 +1,6 @@
 package pool
 
 import (
-	"context"
-	"fmt"
-	"io/ioutil"
-	"os"
-
-	"github.com/lightninglabs/pool/clientdb"
-	"github.com/lightningnetwork/lnd/kvdb"
-	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/lightningnetwork/lnd/macaroons"
-	"github.com/lightningnetwork/lnd/rpcperms"
-	"go.etcd.io/bbolt"
-	"google.golang.org/grpc"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 
@@ -153,30 +141,6 @@ var (
 		}},
 	}
 
-	// allPermissions is the list of all existing permissions that exist
-	// for poold's RPC. The default macaroon that is created on startup
-	// contains all these permissions and is therefore equivalent to lnd's
-	// admin.macaroon but for pool.
-	allPermissions = []bakery.Op{{
-		Entity: "account",
-		Action: "read",
-	}, {
-		Entity: "account",
-		Action: "write",
-	}, {
-		Entity: "order",
-		Action: "read",
-	}, {
-		Entity: "order",
-		Action: "write",
-	}, {
-		Entity: "auction",
-		Action: "read",
-	}, {
-		Entity: "auth",
-		Action: "read",
-	}}
-
 	// macDbDefaultPw is the default encryption password used to encrypt the
 	// pool macaroon database. The macaroon service requires us to set a
 	// non-nil password so we set it to an empty string. This will cause the
@@ -188,121 +152,3 @@ var (
 	// though.
 	macDbDefaultPw = []byte("")
 )
-
-// startMacaroonService starts the macaroon validation service, creates or
-// unlocks the macaroon database and creates the default macaroon if it doesn't
-// exist yet. If macaroons are disabled in general in the configuration, none of
-// these actions are taken.
-func (s *Server) startMacaroonService(createDefaultMacaroonFile bool) error {
-	var err error
-	s.macaroonDB, err = kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
-		DBPath:     s.cfg.BaseDir,
-		DBFileName: "macaroons.db",
-		DBTimeout:  clientdb.DefaultPoolDBTimeout,
-	})
-	if err == bbolt.ErrTimeout {
-		return fmt.Errorf("error while trying to open %s/%s: "+
-			"timed out after %v when trying to obtain exclusive "+
-			"lock - make sure no other pool daemon process "+
-			"(standalone or embedded in lightning-terminal) is "+
-			"running", s.cfg.BaseDir, "macaroons.db",
-			clientdb.DefaultPoolDBTimeout)
-	}
-	if err != nil {
-		return fmt.Errorf("unable to load macaroon db: %v", err)
-	}
-
-	// Create the macaroon authentication/authorization service.
-	s.macaroonService, err = macaroons.NewService(
-		s.macaroonDB, poolMacaroonLocation, false,
-		macaroons.IPLockChecker,
-	)
-	if err != nil {
-		return fmt.Errorf("unable to set up macaroon service: %v", err)
-	}
-
-	// Try to unlock the macaroon store with the private password.
-	err = s.macaroonService.CreateUnlock(&macDbDefaultPw)
-	if err != nil {
-		return fmt.Errorf("unable to unlock macaroon DB: %v", err)
-	}
-
-	// There are situations in which we don't want a macaroon to be created
-	// on disk (for example when running inside LiT stateless integrated
-	// mode). For any other cases, we create macaroon files for the pool CLI
-	// in the default directory.
-	if createDefaultMacaroonFile && !lnrpc.FileExists(s.cfg.MacaroonPath) {
-		// We don't offer the ability to rotate macaroon root keys yet,
-		// so just use the default one since the service expects some
-		// value to be set.
-		idCtx := macaroons.ContextWithRootKeyID(
-			context.Background(), macaroons.DefaultRootKeyID,
-		)
-
-		// We only generate one default macaroon that contains all
-		// existing permissions (equivalent to the admin.macaroon in
-		// lnd). Custom macaroons can be created through the bakery
-		// RPC.
-		poolMac, err := s.macaroonService.Oven.NewMacaroon(
-			idCtx, bakery.LatestVersion, nil, allPermissions...,
-		)
-		if err != nil {
-			return err
-		}
-		poolMacBytes, err := poolMac.M().MarshalBinary()
-		if err != nil {
-			return err
-		}
-		err = ioutil.WriteFile(s.cfg.MacaroonPath, poolMacBytes, 0644)
-		if err != nil {
-			if err := os.Remove(s.cfg.MacaroonPath); err != nil {
-				log.Errorf("Unable to remove %s: %v",
-					s.cfg.MacaroonPath, err)
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-// stopMacaroonService closes the macaroon database.
-func (s *Server) stopMacaroonService() error {
-	var shutdownErr error
-	if err := s.macaroonService.Close(); err != nil {
-		log.Errorf("Error closing macaroon service: %v", err)
-		shutdownErr = err
-	}
-
-	if err := s.macaroonDB.Close(); err != nil {
-		log.Errorf("Error closing macaroon DB: %v", err)
-		shutdownErr = err
-	}
-
-	return shutdownErr
-}
-
-// macaroonInterceptor creates gRPC server options with the macaroon security
-// interceptors.
-func (s *Server) macaroonInterceptor() (grpc.UnaryServerInterceptor,
-	grpc.StreamServerInterceptor, error) {
-
-	interceptor := rpcperms.NewInterceptorChain(log, false, nil)
-	err := interceptor.Start()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	interceptor.SetWalletUnlocked()
-	interceptor.AddMacaroonService(s.macaroonService)
-	for method, permissions := range RequiredPermissions {
-		err := interceptor.AddPermission(method, permissions)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	unaryInterceptor := interceptor.MacaroonUnaryServerInterceptor()
-	streamInterceptor := interceptor.MacaroonStreamServerInterceptor()
-	return unaryInterceptor, streamInterceptor, nil
-}

--- a/server.go
+++ b/server.go
@@ -340,8 +340,7 @@ func (s *Server) Start() error {
 // StartAsSubserver is an alternative start method where the RPC server does not
 // create its own gRPC server but registers on an existing one.
 func (s *Server) StartAsSubserver(lndClient lnrpc.LightningClient,
-	lndGrpc *lndclient.GrpcLndServices,
-	createDefaultMacaroonFile bool) error {
+	lndGrpc *lndclient.GrpcLndServices, withMacaroonService bool) error {
 
 	if atomic.AddInt32(&s.started, 1) != 1 {
 		return fmt.Errorf("trader can only be started once")
@@ -366,7 +365,7 @@ func (s *Server) StartAsSubserver(lndClient lnrpc.LightningClient,
 		}
 	}()
 
-	if createDefaultMacaroonFile {
+	if withMacaroonService {
 		// Create and start the macaroon service and let it create its default
 		// macaroon in case it doesn't exist yet.
 		var err error

--- a/server.go
+++ b/server.go
@@ -25,7 +25,6 @@ import (
 	"github.com/lightninglabs/pool/order"
 	"github.com/lightninglabs/pool/poolrpc"
 	"github.com/lightninglabs/pool/terms"
-	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
@@ -95,8 +94,7 @@ type Server struct {
 	grpcListener    net.Listener
 	restListener    net.Listener
 	restCancel      func()
-	macaroonDB      kvdb.Backend
-	macaroonService *macaroons.Service
+	macaroonService *lndclient.MacaroonService
 	wg              sync.WaitGroup
 }
 
@@ -154,12 +152,32 @@ func (s *Server) Start() error {
 		return err
 	}
 
-	// Start the macaroon service and let it create its default macaroon in
-	// case it doesn't exist yet.
-	if err := s.startMacaroonService(true); err != nil {
+	// Create and start the macaroon service and let it create its default
+	// macaroon in case it doesn't exist yet.
+	s.macaroonService, err = lndclient.NewMacaroonService(
+		&lndclient.MacaroonServiceConfig{
+			DBPath:           s.cfg.BaseDir,
+			DBTimeout:        clientdb.DefaultPoolDBTimeout,
+			MacaroonLocation: poolMacaroonLocation,
+			MacaroonPath:     s.cfg.MacaroonPath,
+			Checkers: []macaroons.Checker{
+				macaroons.IPLockChecker,
+			},
+			RequiredPerms: RequiredPermissions,
+			DBPassword:    macDbDefaultPw,
+			LndClient:     &s.lndServices.LndServices,
+			EphemeralKey:  lndclient.SharedKeyNUMS,
+			KeyLocator:    lndclient.SharedKeyLocator,
+		},
+	)
+	if err != nil {
 		return err
 	}
-	shutdownFuncs["macaroon"] = s.stopMacaroonService
+
+	if err := s.macaroonService.Start(); err != nil {
+		return err
+	}
+	shutdownFuncs["macaroon"] = s.macaroonService.Stop
 
 	// Setup the auctioneer client and interceptor.
 	err = s.setupClient()
@@ -179,7 +197,7 @@ func (s *Server) Start() error {
 
 	// Let's create our interceptor chain, starting with the security
 	// interceptors that will check macaroons for their validity.
-	unaryMacIntercept, streamMacIntercept, err := s.macaroonInterceptor()
+	unaryMacIntercept, streamMacIntercept, err := s.macaroonService.Interceptors()
 	if err != nil {
 		return fmt.Errorf("error with macaroon interceptor: %v", err)
 	}
@@ -348,12 +366,35 @@ func (s *Server) StartAsSubserver(lndClient lnrpc.LightningClient,
 		}
 	}()
 
-	// Start the macaroon service and let it create its default macaroon in
-	// case it doesn't exist yet.
-	if err := s.startMacaroonService(createDefaultMacaroonFile); err != nil {
-		return err
+	if createDefaultMacaroonFile {
+		// Create and start the macaroon service and let it create its default
+		// macaroon in case it doesn't exist yet.
+		var err error
+		s.macaroonService, err = lndclient.NewMacaroonService(
+			&lndclient.MacaroonServiceConfig{
+				DBPath:           s.cfg.BaseDir,
+				DBTimeout:        clientdb.DefaultPoolDBTimeout,
+				MacaroonLocation: poolMacaroonLocation,
+				MacaroonPath:     s.cfg.MacaroonPath,
+				Checkers: []macaroons.Checker{
+					macaroons.IPLockChecker,
+				},
+				RequiredPerms: RequiredPermissions,
+				DBPassword:    macDbDefaultPw,
+				LndClient:     &s.lndServices.LndServices,
+				EphemeralKey:  lndclient.SharedKeyNUMS,
+				KeyLocator:    lndclient.SharedKeyLocator,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		if err := s.macaroonService.Start(); err != nil {
+			return err
+		}
+		shutdownFuncs["macaroon"] = s.macaroonService.Stop
 	}
-	shutdownFuncs["macaroon"] = s.stopMacaroonService
 
 	// Setup the auctioneer client and interceptor.
 	err := s.setupClient()
@@ -393,6 +434,10 @@ func (s *Server) StartAsSubserver(lndClient lnrpc.LightningClient,
 // as lnd but still validate its own macaroons.
 func (s *Server) ValidateMacaroon(ctx context.Context,
 	requiredPermissions []bakery.Op, fullMethod string) error {
+
+	if s.macaroonService == nil {
+		return fmt.Errorf("macaroon service has not been initialised")
+	}
 
 	// Delegate the call to pool's own macaroon validator service.
 	return s.macaroonService.ValidateMacaroon(
@@ -599,8 +644,10 @@ func (s *Server) Stop() error {
 	if err := s.db.Close(); err != nil {
 		log.Errorf("Error closing DB: %v", err)
 	}
-	if err := s.stopMacaroonService(); err != nil {
-		log.Errorf("Error stopping macaroon service: %v", err)
+	if s.macaroonService != nil {
+		if err := s.macaroonService.Stop(); err != nil {
+			log.Errorf("Error stopping macaroon service: %v", err)
+		}
 	}
 	s.lndServices.Close()
 	s.wg.Wait()


### PR DESCRIPTION
Since the code for creating and using a macaroon service is the same for
multiple projects (pool, loop, litd etc), the code has been unified in
lndclient. So this commit removes the macaroon service code and instead
uses the lndclient code.

Depends on https://github.com/lightninglabs/lndclient/pull/86
