### PR TITLE
rpcserver: fix nil version in subserver mode

### DIFF
--- a/server.go
+++ b/server.go
@@ -83,8 +83,6 @@ type Server struct {
 	// client or an error if none has been established yet.
 	GetIdentity func() (*lsat.TokenID, error)
 
-	lndVersion *verrpc.Version
-
 	cfg             *Config
 	db              *clientdb.DB
 	fundingManager  *funding.Manager
@@ -141,11 +139,6 @@ func (s *Server) Start() error {
 		s.lndServices.Close()
 		return nil
 	}
-
-	// Now that we have lnd, lets extract the current version so we can use
-	// this to gate features that we'll use based on the functionality
-	// available.
-	s.lndVersion = s.lndServices.Version
 
 	// As there're some other lower-level operations we may need access to,
 	// we'll also make a connection for a "basic client".


### PR DESCRIPTION
A new variable for the connected lnd node's version was added but was
not given a value when run in subserver mode within LiT.
This commit uses the lnd service's cached version directly and removes
the uninitialized variable.
