### PR TITLE
rpcserver: roll back #330

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1303,7 +1303,13 @@ func (s *rpcServer) SubmitOrder(ctx context.Context,
 			s.server.lndServices.Version, scriptEnforceVersion,
 		)
 		if verErr == nil {
-			return order.ChannelTypeScriptEnforced
+			// TODO(guggero): Use order.ChannelTypeScriptEnforced
+			// here as soon as a large percentage of ask orders
+			// support script enforced channel types to not cause a
+			// market segregation for lnd 0.14.x or later users
+			// without them being aware of why their bids aren't
+			// getting matched.
+			return order.ChannelTypePeerDependent
 		}
 
 		return order.ChannelTypePeerDependent


### PR DESCRIPTION
To fix an accidental market segregation for lnd 0.14.x users that didn't
set an explicit channel type in their bid orders, we roll back the
changes from #330.
We can re-enable this default value selection once a large number of ask
orders support the new channel type.

Fixes https://github.com/lightninglabs/pool/issues/349.
