### PR TITLE
cmd/debug: add DeleteOrder command

### DIFF
--- a/order/interfaces.go
+++ b/order/interfaces.go
@@ -757,6 +757,12 @@ type Store interface {
 	// GetOrders returns all orders that are currently known to the store.
 	GetOrders() ([]Order, error)
 
+	// DeleteOrder removes the order with the given Nonce.
+	//
+	// Note: this method deletes the order without checking if it is
+	// referenced somewhere else (e.g. pending batch).
+	DeleteOrder(Nonce) error
+
 	// StorePendingBatch atomically stages all modified orders/accounts as a
 	// result of a pending batch. If any single operation fails, the whole
 	// set of changes is rolled back. Once the batch has been

--- a/order/mock_interfaces.go
+++ b/order/mock_interfaces.go
@@ -131,6 +131,20 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
+// DeleteOrder mocks base method.
+func (m *MockStore) DeleteOrder(arg0 Nonce) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOrder", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteOrder indicates an expected call of DeleteOrder.
+func (mr *MockStoreMockRecorder) DeleteOrder(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOrder", reflect.TypeOf((*MockStore)(nil).DeleteOrder), arg0)
+}
+
 // GetOrder mocks base method.
 func (m *MockStore) GetOrder(arg0 Nonce) (Order, error) {
 	m.ctrl.T.Helper()

--- a/order/mock_test.go
+++ b/order/mock_test.go
@@ -83,8 +83,8 @@ func (s *mockStore) GetOrders() ([]Order, error) {
 	return orders, nil
 }
 
-// DelOrder removes the order with the given nonce from the local store.
-func (s *mockStore) DelOrder(nonce Nonce) error {
+// DeleteOrder removes the order with the given nonce from the local store.
+func (s *mockStore) DeleteOrder(nonce Nonce) error {
 	delete(s.orders, nonce)
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -770,7 +770,8 @@ func (s *Server) syncLocalOrderState() error {
 			context.Background(), orderNonce,
 		)
 		if err != nil {
-			return fmt.Errorf("unable to fetch order state: %v", err)
+			return fmt.Errorf("unable to fetch order(%v): %v",
+				orderNonce, err)
 		}
 		remoteOrderState, err := rpcOrderStateToDBState(
 			orderStateResp.State,


### PR DESCRIPTION
Enable deleting orders in the local db using the debug cli. This can be used to clean the local db in case it gets out of sync with the server.

**DANGER**: if the user deletes an order from the local db and that order exists in the server, the user will get disconnected when that order matches (and won't be able to trade). The only solution then is to nuke the local db, restore the account and recreate the orders.

unblocks #357 
