### PR TITLE
docker: bump go version + set arch platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine as builder
+FROM --platform=${BUILDPLATFORM} golang:1.16-alpine as builder
 
 # Copy in the local repository to build from.
 COPY . /go/src/github.com/lightninglabs/pool
@@ -18,7 +18,7 @@ RUN apk add --no-cache --update alpine-sdk \
 &&  make install
 
 # Start a new, final image to reduce size.
-FROM alpine as final
+FROM --platform=${BUILDPLATFORM} alpine as final
 
 # Expose poold ports (gRPC and REST).
 EXPOSE 12010 8281


### PR DESCRIPTION
Some users were not able to build [multi arch images with docker](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/). It looks like we need to propagate the `${BUILDPLATFORM}` to all the docker stages.

I also had to bump the go version to make this work `docker buildx build --platform linux/arm64/v8 -f Dockerfile .`, not sure if something changed in the last three versions of go for arm :eyes:



