### PR TITLE
poolscript: make sure negation works with btcec v2

### DIFF
--- a/poolscript/script.go
+++ b/poolscript/script.go
@@ -304,9 +304,13 @@ func DecrementKey(pubKey *btcec.PublicKey) *btcec.PublicKey {
 	// Multiply G by 1 to get G.
 	secp.ScalarBaseMultNonConst(new(secp.ModNScalar).SetInt(1), &g)
 
-	// Get -G by negating the Y axis.
+	// Get -G by negating the Y axis. We normalize first, so we can negate
+	// with the magnitude of 1 and then again to make sure everything is
+	// normalized again after the negation.
+	g.ToAffine()
 	g.Y.Normalize()
 	g.Y.Negate(1)
+	g.Y.Normalize()
 
 	//  priorKey = key - G
 	//  priorKey = (key.x, key.y) + (G.x, -G.y)


### PR DESCRIPTION
Something I noticed when taking a closer look at how the btcec V2 library works.
Not sure if this is really necessary or not, any thoughts, @Roasbeef?
The unit tests all passed fine without this, but maybe this could be an edge case?