### PR TITLE
funding: don't abort if cleanup fails

### DIFF
--- a/funding/batch.go
+++ b/funding/batch.go
@@ -2,10 +2,10 @@ package funding
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/btcsuite/btcd/wire"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/pool/order"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -100,8 +100,13 @@ func AbandonCanceledChannels(matchedOrders map[order.Nonce][]*order.MatchedOrder
 				batchTx, wallet, ourOrder, matchedOrder,
 			)
 			if err != nil {
-				return fmt.Errorf("error locating channel "+
-					"outpoint: %v", err)
+				log.Warnf("Could not find channel output for "+
+					"our_order=%v, matched_order=%v in "+
+					"latest batch TX=%v",
+					ourOrderNonce.String(),
+					matchedOrder.Order.Nonce(),
+					spew.Sdump(batchTx))
+				continue
 			}
 
 			channelPoint := &lnrpc.ChannelPoint{


### PR DESCRIPTION
If we can't clean up pending channels from a previous batch attempt,
that shouldn't block startup. So instead of shutting down, we just log
the warning and continue.

Not sure how the DB got into that state, but this error is what's preventing LiT from starting in this case: https://github.com/lightninglabs/lightning-terminal/issues/372

#### Pull Request Checklist
- [ ] LndServices minimum version has been updated if new lnd apis/fields are
  used.
