### PR TITLE
multi: make profile IP configurable

### DIFF
--- a/cmd/poold/main.go
+++ b/cmd/poold/main.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	"fmt"
-	"net"
-	"net/http"
 	_ "net/http/pprof" // nolint:gosec
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/jessevdk/go-flags"
@@ -64,23 +61,6 @@ func start() error {
 	// Make sure the passed configuration is valid.
 	if err := pool.Validate(&config); err != nil {
 		return err
-	}
-
-	// Enable http profiling and Validate profile port number if reqeusted.
-	if config.Profile != "" {
-		profilePort, err := strconv.Atoi(config.Profile)
-		if err != nil || profilePort < 1024 || profilePort > 65535 {
-			return fmt.Errorf("the profile port must be between " +
-				"1024 and 65535")
-		}
-
-		go func() {
-			listenAddr := net.JoinHostPort("", config.Profile)
-			profileRedirect := http.RedirectHandler("/debug/pprof",
-				http.StatusSeeOther)
-			http.Handle("/", profileRedirect)
-			fmt.Println(http.ListenAndServe(listenAddr, nil))
-		}()
 	}
 
 	// Execute command.

--- a/run.go
+++ b/run.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 
@@ -39,6 +40,17 @@ func Run(cfg *Config) error {
 	err = build.ParseAndSetDebugLevels(cfg.DebugLevel, logWriter)
 	if err != nil {
 		return err
+	}
+
+	if cfg.Profile != "" {
+		go func() {
+			log.Infof("Pprof listening on %v", cfg.Profile)
+			profileRedirect := http.RedirectHandler(
+				"/debug/pprof", http.StatusSeeOther,
+			)
+			http.Handle("/", profileRedirect)
+			fmt.Println(http.ListenAndServe(cfg.Profile, nil))
+		}()
 	}
 
 	trader := NewServer(cfg)


### PR DESCRIPTION
Replaces #228.

Makes the IP address of the profile listener configurable and uses `localhost` if only a port is specified.

#### Pull Request Checklist
- [ ] LndServices minimum version has been updated if new lnd apis/fields are
  used.
