### PR TITLE
scripts: use `git describe --tags`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GOFUZZ := go test -fuzztime 1m -fuzz
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -name "*pb.go" -not -name "*pb.gw.go" -not -name "*.pb.json.go")
 GOLIST := go list -deps $(PKG)/... | grep '$(PKG)'| grep -v '/vendor/'
 
-COMMIT := $(shell git describe --abbrev=40 --dirty)
+COMMIT := $(shell git describe --tags --dirty)
 LDFLAGS := -X $(PKG).Commit=$(COMMIT)
 
 RM := rm -f

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,7 +30,7 @@ function check_tag_correct() {
   local tag=$1
 
   # If a tag is specified, ensure that that tag is present and checked out.
-  if [[ $tag != $(git describe) ]]; then
+  if [[ $tag != $(git describe --tags) ]]; then
     red "tag $tag not checked out"
     exit 1
   fi


### PR DESCRIPTION
When building a release we want to use the right tag, even if it was not annotated.

Fix #417 