### PR TITLE
version: bump to v0.6.2-beta

### DIFF
--- a/version.go
+++ b/version.go
@@ -29,7 +29,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 6
-	appPatch uint = 1
+	appPatch uint = 2
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
The previous version of pool could not be used properly as a subserver because of how it was handling the (sub)-server shutdown.

`v0.6.2-beta` includes a fix for it.