### PR TITLE
rpcserver: format rpcLog error

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -238,7 +238,9 @@ func (s *rpcServer) Stop() error {
 }
 
 // serverHandler is the main event loop of the server.
-func (s *rpcServer) serverHandler(blockChan chan int32, blockErrChan chan error) {
+func (s *rpcServer) serverHandler(blockChan chan int32,
+	blockErrChan chan error) {
+
 	defer s.wg.Done()
 
 	for {
@@ -275,7 +277,7 @@ func (s *rpcServer) serverHandler(blockChan chan int32, blockErrChan chan error)
 				}
 			}
 
-			rpcLog.Error("Unknown server error: %v", err)
+			rpcLog.Errorf("Unknown server error: %v", err)
 
 		case height := <-blockChan:
 			rpcLog.Infof("Received new block notification: "+

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -11,6 +11,9 @@ RUN cd /tmp \
   && mkdir -p /tmp/build/.modcache \
   && cd /tmp/tools \
   && go install -trimpath -tags=tools github.com/golangci/golangci-lint/cmd/golangci-lint \
-  && chmod -R 777 /tmp/build/
+  && chmod -R 777 /tmp/build/ \
+  && git config --global --add safe.directory /build 
+  # The last line is needed to ensure that go build is able to gather 
+  # information from the vsc used in the builds to get the commit hash. 
 
 WORKDIR /build


### PR DESCRIPTION
We were using `Error(<string>, <err>)` instead of `Errorf(<string>, <err>)`. The error was appended at the end of the message instead of replacing the `%v` tag in the message.

Fixes #425 