### PR TITLE
build: update go to v1.19.4-beta

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ env:
   GO111MODULE: on
 
   # If you change this value, please change it in the following files as well:
-  # /.travis.yml
   # /Dockerfile
-  GO_VERSION: 1.18.5
+  # /.golanlint-ci
+  GO_VERSION: 1.19.4
 
 jobs:
   ########################

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters-settings:
       - G402 # Look for bad TLS connection settings.
       - G306 # Poor file permissions used when writing to a new file.
   staticcheck:
-    go: "1.18"
+    go: "1.19"
     checks: ["-SA1019"]
 
 linters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.18.5-alpine as builder
+FROM --platform=${BUILDPLATFORM} golang:1.19.4-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/auctioneerrpc/auctioneer.pb.go
+++ b/auctioneerrpc/auctioneer.pb.go
@@ -32,10 +32,9 @@ const (
 	ChannelType_TWEAKLESS ChannelType = 0
 	// The channel uses an anchor-based commitment.
 	ChannelType_ANCHORS ChannelType = 1
-	//
-	//The channel build upon the anchor-based commitment and requires an
-	//additional CLTV of the channel lease maturity on any commitment and HTLC
-	//outputs that pay directly to the channel initiator (the seller).
+	// The channel build upon the anchor-based commitment and requires an
+	// additional CLTV of the channel lease maturity on any commitment and HTLC
+	// outputs that pay directly to the channel initiator (the seller).
 	ChannelType_SCRIPT_ENFORCED_LEASE ChannelType = 2
 )
 
@@ -83,32 +82,25 @@ func (ChannelType) EnumDescriptor() ([]byte, []int) {
 type AuctionAccountState int32
 
 const (
-	//
-	//The account's funding transaction is not yet confirmed on-chain.
+	// The account's funding transaction is not yet confirmed on-chain.
 	AuctionAccountState_STATE_PENDING_OPEN AuctionAccountState = 0
-	//
-	//The account is fully open and confirmed on-chain.
+	// The account is fully open and confirmed on-chain.
 	AuctionAccountState_STATE_OPEN AuctionAccountState = 1
-	//
-	//The account is still open but the CLTV expiry has passed and the trader can
-	//close it without the auctioneer's key. Orders for accounts in this state
-	//won't be accepted.
+	// The account is still open but the CLTV expiry has passed and the trader can
+	// close it without the auctioneer's key. Orders for accounts in this state
+	// won't be accepted.
 	AuctionAccountState_STATE_EXPIRED AuctionAccountState = 2
-	//
-	//The account was modified by a deposit or withdrawal and is currently waiting
-	//for the modifying transaction to confirm.
+	// The account was modified by a deposit or withdrawal and is currently waiting
+	// for the modifying transaction to confirm.
 	AuctionAccountState_STATE_PENDING_UPDATE AuctionAccountState = 3
-	//
-	//The account is closed. The auctioneer doesn't track whether the closing
-	//transaction is already confirmed on-chain or not.
+	// The account is closed. The auctioneer doesn't track whether the closing
+	// transaction is already confirmed on-chain or not.
 	AuctionAccountState_STATE_CLOSED AuctionAccountState = 4
-	//
-	//The account has recently participated in a batch and is not yet confirmed.
+	// The account has recently participated in a batch and is not yet confirmed.
 	AuctionAccountState_STATE_PENDING_BATCH AuctionAccountState = 5
-	//
-	//The account has reached the expiration height while it had a pending update
-	//that hasn't yet confirmed. This allows accounts to be renewed once
-	//confirmed and expired.
+	// The account has reached the expiration height while it had a pending update
+	// that hasn't yet confirmed. This allows accounts to be renewed once
+	// confirmed and expired.
 	AuctionAccountState_STATE_EXPIRED_PENDING_UPDATE AuctionAccountState = 6
 )
 
@@ -166,14 +158,12 @@ type OrderChannelType int32
 const (
 	// Used to set defaults when a trader doesn't specify a channel type.
 	OrderChannelType_ORDER_CHANNEL_TYPE_UNKNOWN OrderChannelType = 0
-	//
-	//The channel type will vary per matched channel based on the features shared
-	//between its participants.
+	// The channel type will vary per matched channel based on the features shared
+	// between its participants.
 	OrderChannelType_ORDER_CHANNEL_TYPE_PEER_DEPENDENT OrderChannelType = 1
-	//
-	//A channel type that builds upon the anchors commitment format to enforce
-	//channel lease maturities in the commitment and HTLC outputs that pay to the
-	//channel initiator/seller.
+	// A channel type that builds upon the anchors commitment format to enforce
+	// channel lease maturities in the commitment and HTLC outputs that pay to the
+	// channel initiator/seller.
 	OrderChannelType_ORDER_CHANNEL_TYPE_SCRIPT_ENFORCED OrderChannelType = 2
 )
 
@@ -221,13 +211,11 @@ func (OrderChannelType) EnumDescriptor() ([]byte, []int) {
 type AuctionType int32
 
 const (
-	//
-	//Default auction type where the bidder is paying for getting bitcoin inbound
-	//liqiudity from the asker.
+	// Default auction type where the bidder is paying for getting bitcoin inbound
+	// liqiudity from the asker.
 	AuctionType_AUCTION_TYPE_BTC_INBOUND_LIQUIDITY AuctionType = 0
-	//
-	//Auction type where the bidder is paying the asker to accept a channel
-	//(bitcoin outbound liquidity) from the bidder.
+	// Auction type where the bidder is paying the asker to accept a channel
+	// (bitcoin outbound liquidity) from the bidder.
 	AuctionType_AUCTION_TYPE_BTC_OUTBOUND_LIQUIDITY AuctionType = 1
 )
 
@@ -492,21 +480,17 @@ func (OrderState) EnumDescriptor() ([]byte, []int) {
 type DurationBucketState int32
 
 const (
-	//
-	//NO_MARKET indicates that this bucket doesn't actually exist, in that no
-	//market is present for this market.
+	// NO_MARKET indicates that this bucket doesn't actually exist, in that no
+	// market is present for this market.
 	DurationBucketState_NO_MARKET DurationBucketState = 0
-	//
-	//MARKET_CLOSED indicates that this market exists, but that it isn't currently
-	//running.
+	// MARKET_CLOSED indicates that this market exists, but that it isn't currently
+	// running.
 	DurationBucketState_MARKET_CLOSED DurationBucketState = 1
-	//
-	//ACCEPTING_ORDERS indicates that we're accepting orders for this bucket, but
-	//not yet clearing for this duration.
+	// ACCEPTING_ORDERS indicates that we're accepting orders for this bucket, but
+	// not yet clearing for this duration.
 	DurationBucketState_ACCEPTING_ORDERS DurationBucketState = 2
-	//
-	//MARKET_OPEN indicates that we're accepting orders, and fully clearing the
-	//market for this duration.
+	// MARKET_OPEN indicates that we're accepting orders, and fully clearing the
+	// market for this duration.
 	DurationBucketState_MARKET_OPEN DurationBucketState = 3
 )
 
@@ -558,17 +542,14 @@ type OrderMatchReject_RejectReason int32
 const (
 	// The reason cannot be mapped to a specific code.
 	OrderMatchReject_UNKNOWN OrderMatchReject_RejectReason = 0
-	//
-	//The client didn't come up with the same result as the server and is
-	//rejecting the batch because of that.
+	// The client didn't come up with the same result as the server and is
+	// rejecting the batch because of that.
 	OrderMatchReject_SERVER_MISBEHAVIOR OrderMatchReject_RejectReason = 1
-	//
-	//The client doesn't support the current batch verification version the
-	//server is using.
+	// The client doesn't support the current batch verification version the
+	// server is using.
 	OrderMatchReject_BATCH_VERSION_MISMATCH OrderMatchReject_RejectReason = 2
-	//
-	//The client rejects some of the orders, not the full batch. When this
-	//code is set, the rejected_orders map must be set.
+	// The client rejects some of the orders, not the full batch. When this
+	// code is set, the rejected_orders map must be set.
 	OrderMatchReject_PARTIAL_REJECT OrderMatchReject_RejectReason = 3
 )
 
@@ -618,18 +599,16 @@ func (OrderMatchReject_RejectReason) EnumDescriptor() ([]byte, []int) {
 type OrderReject_OrderRejectReason int32
 
 const (
-	//
-	//The trader's client has a preference to only match orders with peers it
-	//doesn't already have channels with. The order that is rejected with this
-	//reason type comes from a peer that the trader already has channels with.
+	// The trader's client has a preference to only match orders with peers it
+	// doesn't already have channels with. The order that is rejected with this
+	// reason type comes from a peer that the trader already has channels with.
 	OrderReject_DUPLICATE_PEER OrderReject_OrderRejectReason = 0
-	//
-	//The trader's client couldn't connect to the remote node of the matched
-	//order or the channel funding could not be initialized for another
-	//reason. This could also be the rejecting node's fault if their
-	//connection is not stable. Using this code can have a negative impact on
-	//the reputation score of both nodes, depending on the number of errors
-	//recorded.
+	// The trader's client couldn't connect to the remote node of the matched
+	// order or the channel funding could not be initialized for another
+	// reason. This could also be the rejecting node's fault if their
+	// connection is not stable. Using this code can have a negative impact on
+	// the reputation score of both nodes, depending on the number of errors
+	// recorded.
 	OrderReject_CHANNEL_FUNDING_FAILED OrderReject_OrderRejectReason = 1
 )
 
@@ -675,20 +654,16 @@ func (OrderReject_OrderRejectReason) EnumDescriptor() ([]byte, []int) {
 type SubscribeError_Error int32
 
 const (
-	//
-	//The error cannot be mapped to a specific code.
+	// The error cannot be mapped to a specific code.
 	SubscribeError_UNKNOWN SubscribeError_Error = 0
-	//
-	//The server is shutting down for maintenance. Traders should close the
-	//long-lived stream/connection and try to connect again after some time.
+	// The server is shutting down for maintenance. Traders should close the
+	// long-lived stream/connection and try to connect again after some time.
 	SubscribeError_SERVER_SHUTDOWN SubscribeError_Error = 1
-	//
-	//The account the trader tried to subscribe to does not exist in the
-	//auctioneer's database.
+	// The account the trader tried to subscribe to does not exist in the
+	// auctioneer's database.
 	SubscribeError_ACCOUNT_DOES_NOT_EXIST SubscribeError_Error = 2
-	//
-	//The account the trader tried to subscribe to was never completed and a
-	//reservation for it is still pending.
+	// The account the trader tried to subscribe to was never completed and a
+	// reservation for it is still pending.
 	SubscribeError_INCOMPLETE_ACCOUNT_RESERVATION SubscribeError_Error = 3
 )
 
@@ -835,17 +810,13 @@ type ReserveAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The desired value of the account in satoshis.
+	// The desired value of the account in satoshis.
 	AccountValue uint64 `protobuf:"varint,1,opt,name=account_value,json=accountValue,proto3" json:"account_value,omitempty"`
-	//
-	//The block height at which the account should expire.
+	// The block height at which the account should expire.
 	AccountExpiry uint32 `protobuf:"varint,2,opt,name=account_expiry,json=accountExpiry,proto3" json:"account_expiry,omitempty"`
-	//
-	//The trader's account key.
+	// The trader's account key.
 	TraderKey []byte `protobuf:"bytes,3,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
-	//
-	//The account version. Must be set to 0 for legacy (non-taproot) accounts.
+	// The account version. Must be set to 0 for legacy (non-taproot) accounts.
 	Version uint32 `protobuf:"varint,4,opt,name=version,proto3" json:"version,omitempty"`
 }
 
@@ -914,24 +885,22 @@ type ReserveAccountResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The base key of the auctioneer. This key should be tweaked with the trader's
-	//per-batch tweaked key to obtain the corresponding per-batch tweaked
-	//auctioneer key. Or, in case of the version 1, Taproot enabled account, the
-	//trader and auctioneer key will be combined into a MuSig2 combined key that
-	//is static throughout the lifetime of the account. The on-chain uniqueness of
-	//the generated output will be ensured by the merkle root hash that is applied
-	//as a tweak to the MuSig2 combined internal key. The merkle root hash is
-	//either the hash of the timeout script path (which uses the trader key
-	//tweaked with the per-batch key) directly or the root of a tree with one leaf
-	//that is the timeout script path and a leaf that is a Taro commitment (which
-	//is a root hash by itself).
+	// The base key of the auctioneer. This key should be tweaked with the trader's
+	// per-batch tweaked key to obtain the corresponding per-batch tweaked
+	// auctioneer key. Or, in case of the version 1, Taproot enabled account, the
+	// trader and auctioneer key will be combined into a MuSig2 combined key that
+	// is static throughout the lifetime of the account. The on-chain uniqueness of
+	// the generated output will be ensured by the merkle root hash that is applied
+	// as a tweak to the MuSig2 combined internal key. The merkle root hash is
+	// either the hash of the timeout script path (which uses the trader key
+	// tweaked with the per-batch key) directly or the root of a tree with one leaf
+	// that is the timeout script path and a leaf that is a Taro commitment (which
+	// is a root hash by itself).
 	AuctioneerKey []byte `protobuf:"bytes,1,opt,name=auctioneer_key,json=auctioneerKey,proto3" json:"auctioneer_key,omitempty"`
-	//
-	//The initial per-batch key to be used for the account. For every cleared
-	//batch that the account participates in, this key will be incremented by the
-	//base point of its curve, resulting in a new key for both the trader and
-	//auctioneer in every batch.
+	// The initial per-batch key to be used for the account. For every cleared
+	// batch that the account participates in, this key will be incremented by the
+	// base point of its curve, resulting in a new key for both the trader and
+	// auctioneer in every batch.
 	InitialBatchKey []byte `protobuf:"bytes,2,opt,name=initial_batch_key,json=initialBatchKey,proto3" json:"initial_batch_key,omitempty"`
 }
 
@@ -986,37 +955,34 @@ type ServerInitAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//Transaction output of the account. Has to be unspent and be a P2WSH of
-	//the account script below. The amount must also exactly correspond to the
-	//account value below.
+	// Transaction output of the account. Has to be unspent and be a P2WSH of
+	// the account script below. The amount must also exactly correspond to the
+	// account value below.
 	AccountPoint *OutPoint `protobuf:"bytes,1,opt,name=account_point,json=accountPoint,proto3" json:"account_point,omitempty"`
-	//
-	//The script used to create the account point. For version 1 (Taproot enabled)
-	//accounts this represents the 32-byte (x-only) Taproot public key with the
-	//combined MuSig2 key of the auctioneer's key and the trader's key with the
-	//expiry script path applied as a single tapscript leaf.
+	// The script used to create the account point. For version 1 (Taproot enabled)
+	// accounts this represents the 32-byte (x-only) Taproot public key with the
+	// combined MuSig2 key of the auctioneer's key and the trader's key with the
+	// expiry script path applied as a single tapscript leaf.
 	AccountScript []byte `protobuf:"bytes,2,opt,name=account_script,json=accountScript,proto3" json:"account_script,omitempty"`
-	//
-	//The value of the account in satoshis. Must match the amount of the
-	//account_point output.
+	// The value of the account in satoshis. Must match the amount of the
+	// account_point output.
 	AccountValue uint64 `protobuf:"varint,3,opt,name=account_value,json=accountValue,proto3" json:"account_value,omitempty"`
-	//
-	//The block height at which the account should expire.
+	// The block height at which the account should expire.
 	AccountExpiry uint32 `protobuf:"varint,4,opt,name=account_expiry,json=accountExpiry,proto3" json:"account_expiry,omitempty"`
-	//
-	//The trader's account key.
+	// The trader's account key.
 	TraderKey []byte `protobuf:"bytes,5,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
 	// The user agent string that identifies the software running on the user's
 	// side. This can be changed in the user's client software but it _SHOULD_
 	// conform to the following pattern and use less than 256 characters:
-	//    Agent-Name/semver-version(/additional-info)
-	// Examples:
-	//    poold/v0.4.2-beta/commit=3b635821,initiator=pool-cli
-	//    litd/v0.4.0-alpha/commit=326d754,initiator=lit-ui
-	UserAgent string `protobuf:"bytes,6,opt,name=user_agent,json=userAgent,proto3" json:"user_agent,omitempty"`
 	//
-	//The account version. Must be set to 0 for legacy (non-taproot) accounts.
+	//	Agent-Name/semver-version(/additional-info)
+	//
+	// Examples:
+	//
+	//	poold/v0.4.2-beta/commit=3b635821,initiator=pool-cli
+	//	litd/v0.4.0-alpha/commit=326d754,initiator=lit-ui
+	UserAgent string `protobuf:"bytes,6,opt,name=user_agent,json=userAgent,proto3" json:"user_agent,omitempty"`
+	// The account version. Must be set to 0 for legacy (non-taproot) accounts.
 	Version uint32 `protobuf:"varint,7,opt,name=version,proto3" json:"version,omitempty"`
 }
 
@@ -1145,16 +1111,20 @@ type ServerSubmitOrderRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Details:
+	//
 	//	*ServerSubmitOrderRequest_Ask
 	//	*ServerSubmitOrderRequest_Bid
 	Details isServerSubmitOrderRequest_Details `protobuf_oneof:"details"`
 	// The user agent string that identifies the software running on the user's
 	// side. This can be changed in the user's client software but it _SHOULD_
 	// conform to the following pattern and use less than 256 characters:
-	//    Agent-Name/semver-version(/additional-info)
+	//
+	//	Agent-Name/semver-version(/additional-info)
+	//
 	// Examples:
-	//    poold/v0.4.2-beta/commit=3b635821,initiator=pool-cli
-	//    litd/v0.4.0-alpha/commit=326d754,initiator=lit-ui
+	//
+	//	poold/v0.4.2-beta/commit=3b635821,initiator=pool-cli
+	//	litd/v0.4.0-alpha/commit=326d754,initiator=lit-ui
 	UserAgent string `protobuf:"bytes,3,opt,name=user_agent,json=userAgent,proto3" json:"user_agent,omitempty"`
 }
 
@@ -1223,14 +1193,12 @@ type isServerSubmitOrderRequest_Details interface {
 }
 
 type ServerSubmitOrderRequest_Ask struct {
-	//
-	//Submit an ask order.
+	// Submit an ask order.
 	Ask *ServerAsk `protobuf:"bytes,1,opt,name=ask,proto3,oneof"`
 }
 
 type ServerSubmitOrderRequest_Bid struct {
-	//
-	//Submit a bid order.
+	// Submit a bid order.
 	Bid *ServerBid `protobuf:"bytes,2,opt,name=bid,proto3,oneof"`
 }
 
@@ -1244,6 +1212,7 @@ type ServerSubmitOrderResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Details:
+	//
 	//	*ServerSubmitOrderResponse_InvalidOrder
 	//	*ServerSubmitOrderResponse_Accepted
 	Details isServerSubmitOrderResponse_Details `protobuf_oneof:"details"`
@@ -1307,14 +1276,12 @@ type isServerSubmitOrderResponse_Details interface {
 }
 
 type ServerSubmitOrderResponse_InvalidOrder struct {
-	//
-	//Order failed with the given reason.
+	// Order failed with the given reason.
 	InvalidOrder *InvalidOrder `protobuf:"bytes,1,opt,name=invalid_order,json=invalidOrder,proto3,oneof"`
 }
 
 type ServerSubmitOrderResponse_Accepted struct {
-	//
-	//Order was accepted.
+	// Order was accepted.
 	Accepted bool `protobuf:"varint,2,opt,name=accepted,proto3,oneof"`
 }
 
@@ -1327,8 +1294,7 @@ type ServerCancelOrderRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The preimage to the order's unique nonce.
+	// The preimage to the order's unique nonce.
 	OrderNoncePreimage []byte `protobuf:"bytes,1,opt,name=order_nonce_preimage,json=orderNoncePreimage,proto3" json:"order_nonce_preimage,omitempty"`
 }
 
@@ -1415,6 +1381,7 @@ type ClientAuctionMessage struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Msg:
+	//
 	//	*ClientAuctionMessage_Commit
 	//	*ClientAuctionMessage_Subscribe
 	//	*ClientAuctionMessage_Accept
@@ -1510,48 +1477,42 @@ type isClientAuctionMessage_Msg interface {
 }
 
 type ClientAuctionMessage_Commit struct {
-	//
-	//Signal the intent to receive updates about a certain account and start
-	//by sending the commitment part of the authentication handshake. This is
-	//step 1 of the 3-way handshake.
+	// Signal the intent to receive updates about a certain account and start
+	// by sending the commitment part of the authentication handshake. This is
+	// step 1 of the 3-way handshake.
 	Commit *AccountCommitment `protobuf:"bytes,1,opt,name=commit,proto3,oneof"`
 }
 
 type ClientAuctionMessage_Subscribe struct {
-	//
-	//Subscribe to update and interactive order execution events for account
-	//given and all its orders. Contains the final signature and is step 3 of
-	//the 3-way authentication handshake.
+	// Subscribe to update and interactive order execution events for account
+	// given and all its orders. Contains the final signature and is step 3 of
+	// the 3-way authentication handshake.
 	Subscribe *AccountSubscription `protobuf:"bytes,2,opt,name=subscribe,proto3,oneof"`
 }
 
 type ClientAuctionMessage_Accept struct {
-	//
-	//Accept the orders to be matched.
+	// Accept the orders to be matched.
 	Accept *OrderMatchAccept `protobuf:"bytes,3,opt,name=accept,proto3,oneof"`
 }
 
 type ClientAuctionMessage_Reject struct {
-	//
-	//Reject a whole batch.
+	// Reject a whole batch.
 	Reject *OrderMatchReject `protobuf:"bytes,4,opt,name=reject,proto3,oneof"`
 }
 
 type ClientAuctionMessage_Sign struct {
-	//
-	//The channel funding negotiations with the matched peer were successful
-	//and the inputs to spend from the accounts are now signed.
+	// The channel funding negotiations with the matched peer were successful
+	// and the inputs to spend from the accounts are now signed.
 	Sign *OrderMatchSign `protobuf:"bytes,5,opt,name=sign,proto3,oneof"`
 }
 
 type ClientAuctionMessage_Recover struct {
-	//
-	//The trader has lost its database and is trying to recover their
-	//accounts. This message can be sent after the successful completion of
-	//the 3-way authentication handshake where it will be established if the
-	//account exists on the auctioneer's side. This message must only be sent
-	//if the auctioneer knows of the account, otherwise it will regard it as a
-	//critical error and terminate the connection.
+	// The trader has lost its database and is trying to recover their
+	// accounts. This message can be sent after the successful completion of
+	// the 3-way authentication handshake where it will be established if the
+	// account exists on the auctioneer's side. This message must only be sent
+	// if the auctioneer knows of the account, otherwise it will regard it as a
+	// critical error and terminate the connection.
 	Recover *AccountRecovery `protobuf:"bytes,6,opt,name=recover,proto3,oneof"`
 }
 
@@ -1572,15 +1533,13 @@ type AccountCommitment struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The SHA256 hash of the trader's account key and a 32 byte random nonce.
-	//commit_hash = SHA256(accountPubKey || nonce)
+	// The SHA256 hash of the trader's account key and a 32 byte random nonce.
+	// commit_hash = SHA256(accountPubKey || nonce)
 	CommitHash []byte `protobuf:"bytes,1,opt,name=commit_hash,json=commitHash,proto3" json:"commit_hash,omitempty"`
-	//
-	//The batch verification protocol version the client is using. Clients that
-	//don't use the latest version will be declined to connect and participate in
-	//an auction. The user should then be informed that a software update is
-	//required.
+	// The batch verification protocol version the client is using. Clients that
+	// don't use the latest version will be declined to connect and participate in
+	// an auction. The user should then be informed that a software update is
+	// required.
 	BatchVersion uint32 `protobuf:"varint,2,opt,name=batch_version,json=batchVersion,proto3" json:"batch_version,omitempty"`
 }
 
@@ -1635,17 +1594,14 @@ type AccountSubscription struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The trader's account key of the account to subscribe to.
+	// The trader's account key of the account to subscribe to.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
-	//
-	//The random 32 byte nonce the trader used to create the commitment hash.
+	// The random 32 byte nonce the trader used to create the commitment hash.
 	CommitNonce []byte `protobuf:"bytes,2,opt,name=commit_nonce,json=commitNonce,proto3" json:"commit_nonce,omitempty"`
-	//
-	//The signature over the auth_hash which is the hash of the commitment and
-	//challenge. The signature is created with the trader's account key they
-	//committed to.
-	//auth_hash = SHA256(SHA256(accountPubKey || nonce) || challenge)
+	// The signature over the auth_hash which is the hash of the commitment and
+	// challenge. The signature is created with the trader's account key they
+	// committed to.
+	// auth_hash = SHA256(SHA256(accountPubKey || nonce) || challenge)
 	AuthSig []byte `protobuf:"bytes,3,opt,name=auth_sig,json=authSig,proto3" json:"auth_sig,omitempty"`
 }
 
@@ -1707,9 +1663,8 @@ type OrderMatchAccept struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The batch ID this acceptance message refers to. Must be set to avoid out-of-
-	//order responses from disrupting the batching process.
+	// The batch ID this acceptance message refers to. Must be set to avoid out-of-
+	// order responses from disrupting the batching process.
 	BatchId []byte `protobuf:"bytes,1,opt,name=batch_id,json=batchId,proto3" json:"batch_id,omitempty"`
 }
 
@@ -1757,29 +1712,25 @@ type OrderMatchReject struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The ID of the batch to reject.
+	// The ID of the batch to reject.
 	BatchId []byte `protobuf:"bytes,1,opt,name=batch_id,json=batchId,proto3" json:"batch_id,omitempty"`
-	//
-	//The reason/error string for the rejection.
+	// The reason/error string for the rejection.
 	Reason string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
-	//
-	//The reason as a code.
+	// The reason as a code.
 	ReasonCode OrderMatchReject_RejectReason `protobuf:"varint,3,opt,name=reason_code,json=reasonCode,proto3,enum=poolrpc.OrderMatchReject_RejectReason" json:"reason_code,omitempty"`
+	// The map of order nonces the trader was matched with but doesn't accept. The
+	// map contains the _other_ trader's order nonces and the reason for rejecting
+	// them. This can be a subset of the whole list of orders presented as matches
+	// if the trader only wants to reject some of them. This map is only
+	// considered by the auctioneer if the main reason_code is set to
+	// PARTIAL_REJECT. Otherwise it is assumed that the whole batch was faulty for
+	// some reason and that the trader rejects all orders contained. The auctioneer
+	// will only accept a certain number of these partial rejects before a trader's
+	// account is removed completely from the current batch. Abusing this
+	// functionality can also lead to a ban of the trader.
 	//
-	//The map of order nonces the trader was matched with but doesn't accept. The
-	//map contains the _other_ trader's order nonces and the reason for rejecting
-	//them. This can be a subset of the whole list of orders presented as matches
-	//if the trader only wants to reject some of them. This map is only
-	//considered by the auctioneer if the main reason_code is set to
-	//PARTIAL_REJECT. Otherwise it is assumed that the whole batch was faulty for
-	//some reason and that the trader rejects all orders contained. The auctioneer
-	//will only accept a certain number of these partial rejects before a trader's
-	//account is removed completely from the current batch. Abusing this
-	//functionality can also lead to a ban of the trader.
-	//
-	//The order nonces are hex encoded strings because the protobuf map doesn't
-	//allow raw bytes to be the map key type.
+	// The order nonces are hex encoded strings because the protobuf map doesn't
+	// allow raw bytes to be the map key type.
 	RejectedOrders map[string]*OrderReject `protobuf:"bytes,4,rep,name=rejected_orders,json=rejectedOrders,proto3" json:"rejected_orders,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -1848,11 +1799,9 @@ type OrderReject struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The reason/error string for the rejection.
+	// The reason/error string for the rejection.
 	Reason string `protobuf:"bytes,1,opt,name=reason,proto3" json:"reason,omitempty"`
-	//
-	//The reason as a code.
+	// The reason as a code.
 	ReasonCode OrderReject_OrderRejectReason `protobuf:"varint,2,opt,name=reason_code,json=reasonCode,proto3,enum=poolrpc.OrderReject_OrderRejectReason" json:"reason_code,omitempty"`
 }
 
@@ -1913,13 +1862,11 @@ type ChannelInfo struct {
 	LocalNodeKey []byte `protobuf:"bytes,2,opt,name=local_node_key,json=localNodeKey,proto3" json:"local_node_key,omitempty"`
 	// The remote node's identifying public key.
 	RemoteNodeKey []byte `protobuf:"bytes,3,opt,name=remote_node_key,json=remoteNodeKey,proto3" json:"remote_node_key,omitempty"`
-	//
-	//The node's base public key used within the non-delayed pay-to-self output on
-	//the commitment transaction.
+	// The node's base public key used within the non-delayed pay-to-self output on
+	// the commitment transaction.
 	LocalPaymentBasePoint []byte `protobuf:"bytes,4,opt,name=local_payment_base_point,json=localPaymentBasePoint,proto3" json:"local_payment_base_point,omitempty"`
-	//
-	//RemotePaymentBasePoint is the remote node's base public key used within the
-	//non-delayed pay-to-self output on the commitment transaction.
+	// RemotePaymentBasePoint is the remote node's base public key used within the
+	// non-delayed pay-to-self output on the commitment transaction.
 	RemotePaymentBasePoint []byte `protobuf:"bytes,5,opt,name=remote_payment_base_point,json=remotePaymentBasePoint,proto3" json:"remote_payment_base_point,omitempty"`
 }
 
@@ -1995,31 +1942,27 @@ type OrderMatchSign struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The ID of the batch that the signatures are meant for.
+	// The ID of the batch that the signatures are meant for.
 	BatchId []byte `protobuf:"bytes,1,opt,name=batch_id,json=batchId,proto3" json:"batch_id,omitempty"`
-	//
-	//A map with the signatures to spend the accounts being spent in a batch
-	//transaction. The map key corresponds to the trader's account key of the
-	//account in the batch transaction. The account key/ID has to be hex encoded
-	//into a string because protobuf doesn't allow bytes as a map key data type.
-	//For version 1 (Taproot enabled) accounts, this merely represents a partial
-	//MuSig2 signature that can be combined into a full signature by the auction
-	//server by adding its own partial signature. A set of nonces will be provided
-	//by the trader for each v1 account to allow finalizing the MuSig2 signing
-	//session.
+	// A map with the signatures to spend the accounts being spent in a batch
+	// transaction. The map key corresponds to the trader's account key of the
+	// account in the batch transaction. The account key/ID has to be hex encoded
+	// into a string because protobuf doesn't allow bytes as a map key data type.
+	// For version 1 (Taproot enabled) accounts, this merely represents a partial
+	// MuSig2 signature that can be combined into a full signature by the auction
+	// server by adding its own partial signature. A set of nonces will be provided
+	// by the trader for each v1 account to allow finalizing the MuSig2 signing
+	// session.
 	AccountSigs map[string][]byte `protobuf:"bytes,2,rep,name=account_sigs,json=accountSigs,proto3" json:"account_sigs,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	//
-	//The information for each channel created as part of a batch that's submitted
-	//to the auctioneer to ensure they can properly enforce a channel's service
-	//lifetime. Entries are indexed by the string representation of a channel's
-	//outpoint.
+	// The information for each channel created as part of a batch that's submitted
+	// to the auctioneer to ensure they can properly enforce a channel's service
+	// lifetime. Entries are indexed by the string representation of a channel's
+	// outpoint.
 	ChannelInfos map[string]*ChannelInfo `protobuf:"bytes,3,rep,name=channel_infos,json=channelInfos,proto3" json:"channel_infos,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	//
-	//A set of 66-byte nonces for each version 1 (Taproot enabled) account. The
-	//nonces can be used to produce a MuSig2 partial signature to spend the
-	//account using the key spend path, which is a MuSig2 combined key of the
-	//auctioneer key and the trader key.
+	// A set of 66-byte nonces for each version 1 (Taproot enabled) account. The
+	// nonces can be used to produce a MuSig2 partial signature to spend the
+	// account using the key spend path, which is a MuSig2 combined key of the
+	// auctioneer key and the trader key.
 	TraderNonces map[string][]byte `protobuf:"bytes,4,rep,name=trader_nonces,json=traderNonces,proto3" json:"trader_nonces,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -2088,8 +2031,7 @@ type AccountRecovery struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The trader's account key of the account to recover.
+	// The trader's account key of the account to recover.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
 }
 
@@ -2138,6 +2080,7 @@ type ServerAuctionMessage struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Msg:
+	//
 	//	*ServerAuctionMessage_Challenge
 	//	*ServerAuctionMessage_Success
 	//	*ServerAuctionMessage_Error
@@ -2241,57 +2184,50 @@ type isServerAuctionMessage_Msg interface {
 }
 
 type ServerAuctionMessage_Challenge struct {
-	//
-	//Step 2 of the 3-way authentication handshake. Contains the
-	//authentication challenge. Subscriptions sent by the trader must sign
-	//the message SHA256(SHA256(accountPubKey || nonce) || challenge)
-	//with their account key to prove ownership of said key.
+	// Step 2 of the 3-way authentication handshake. Contains the
+	// authentication challenge. Subscriptions sent by the trader must sign
+	// the message SHA256(SHA256(accountPubKey || nonce) || challenge)
+	// with their account key to prove ownership of said key.
 	Challenge *ServerChallenge `protobuf:"bytes,1,opt,name=challenge,proto3,oneof"`
 }
 
 type ServerAuctionMessage_Success struct {
-	//
-	//The trader has subscribed to account updates successfully, the 3-way
-	//authentication handshake completed normally.
+	// The trader has subscribed to account updates successfully, the 3-way
+	// authentication handshake completed normally.
 	Success *SubscribeSuccess `protobuf:"bytes,2,opt,name=success,proto3,oneof"`
 }
 
 type ServerAuctionMessage_Error struct {
-	//
-	//An error occurred during any part of the communication. The trader
-	//should inspect the error code and act accordingly.
+	// An error occurred during any part of the communication. The trader
+	// should inspect the error code and act accordingly.
 	Error *SubscribeError `protobuf:"bytes,3,opt,name=error,proto3,oneof"`
 }
 
 type ServerAuctionMessage_Prepare struct {
-	//
-	//The auctioneer has matched a set of orders into a batch and now
-	//instructs the traders to validate the batch and prepare for order
-	//execution. Because traders have the possibility of backing out of a
-	//batch, multiple of these messages with the SAME batch_id can be sent.
+	// The auctioneer has matched a set of orders into a batch and now
+	// instructs the traders to validate the batch and prepare for order
+	// execution. Because traders have the possibility of backing out of a
+	// batch, multiple of these messages with the SAME batch_id can be sent.
 	Prepare *OrderMatchPrepare `protobuf:"bytes,4,opt,name=prepare,proto3,oneof"`
 }
 
 type ServerAuctionMessage_Sign struct {
-	//
-	//This message is sent after all traders send back an OrderMatchAccept
-	//method. It signals that the traders should execute their local funding
-	//protocol, then send signatures for their account inputs.
+	// This message is sent after all traders send back an OrderMatchAccept
+	// method. It signals that the traders should execute their local funding
+	// protocol, then send signatures for their account inputs.
 	Sign *OrderMatchSignBegin `protobuf:"bytes,5,opt,name=sign,proto3,oneof"`
 }
 
 type ServerAuctionMessage_Finalize struct {
-	//
-	//All traders have accepted and signed the batch and the final transaction
-	//was broadcast.
+	// All traders have accepted and signed the batch and the final transaction
+	// was broadcast.
 	Finalize *OrderMatchFinalize `protobuf:"bytes,6,opt,name=finalize,proto3,oneof"`
 }
 
 type ServerAuctionMessage_Account struct {
-	//
-	//The answer to a trader's request for account recovery. This message
-	//contains all information that is needed to restore the account to
-	//working order on the trader side.
+	// The answer to a trader's request for account recovery. This message
+	// contains all information that is needed to restore the account to
+	// working order on the trader side.
 	Account *AuctionAccount `protobuf:"bytes,7,opt,name=account,proto3,oneof"`
 }
 
@@ -2314,12 +2250,10 @@ type ServerChallenge struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The unique challenge for each stream that has to be signed with the trader's
-	//account key for each account subscription.
+	// The unique challenge for each stream that has to be signed with the trader's
+	// account key for each account subscription.
 	Challenge []byte `protobuf:"bytes,1,opt,name=challenge,proto3" json:"challenge,omitempty"`
-	//
-	//The commit hash the challenge was created for.
+	// The commit hash the challenge was created for.
 	CommitHash []byte `protobuf:"bytes,2,opt,name=commit_hash,json=commitHash,proto3" json:"commit_hash,omitempty"`
 }
 
@@ -2374,8 +2308,7 @@ type SubscribeSuccess struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The trader's account key this message is referring to.
+	// The trader's account key this message is referring to.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
 }
 
@@ -2423,14 +2356,12 @@ type MatchedMarket struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//Maps a user's own order_nonce to the opposite order type they were matched
-	//with. The order_nonce is a 32 byte hex encoded string because bytes is not
-	//allowed as a map key data type in protobuf.
+	// Maps a user's own order_nonce to the opposite order type they were matched
+	// with. The order_nonce is a 32 byte hex encoded string because bytes is not
+	// allowed as a map key data type in protobuf.
 	MatchedOrders map[string]*MatchedOrder `protobuf:"bytes,1,rep,name=matched_orders,json=matchedOrders,proto3" json:"matched_orders,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	//
-	//The uniform clearing price rate in parts per billion that was used for this
-	//batch.
+	// The uniform clearing price rate in parts per billion that was used for this
+	// batch.
 	ClearingPriceRate uint32 `protobuf:"varint,2,opt,name=clearing_price_rate,json=clearingPriceRate,proto3" json:"clearing_price_rate,omitempty"`
 }
 
@@ -2485,52 +2416,41 @@ type OrderMatchPrepare struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//Deprecated, use matched_markets.
+	// Deprecated, use matched_markets.
 	//
 	// Deprecated: Do not use.
 	MatchedOrders map[string]*MatchedOrder `protobuf:"bytes,1,rep,name=matched_orders,json=matchedOrders,proto3" json:"matched_orders,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	//
-	//Deprecated, use matched_markets.
+	// Deprecated, use matched_markets.
 	//
 	// Deprecated: Do not use.
 	ClearingPriceRate uint32 `protobuf:"varint,2,opt,name=clearing_price_rate,json=clearingPriceRate,proto3" json:"clearing_price_rate,omitempty"`
-	//
-	//A list of the user's own accounts that are being spent by the matched
-	//orders. The list contains the differences that would be applied by the
-	//server when executing the orders.
+	// A list of the user's own accounts that are being spent by the matched
+	// orders. The list contains the differences that would be applied by the
+	// server when executing the orders.
 	ChargedAccounts []*AccountDiff `protobuf:"bytes,3,rep,name=charged_accounts,json=chargedAccounts,proto3" json:"charged_accounts,omitempty"`
-	//
-	//The fee parameters used to calculate the execution fees.
+	// The fee parameters used to calculate the execution fees.
 	ExecutionFee *ExecutionFee `protobuf:"bytes,4,opt,name=execution_fee,json=executionFee,proto3" json:"execution_fee,omitempty"`
-	//
-	//The batch transaction with all non-witness data.
+	// The batch transaction with all non-witness data.
 	BatchTransaction []byte `protobuf:"bytes,5,opt,name=batch_transaction,json=batchTransaction,proto3" json:"batch_transaction,omitempty"`
-	//
-	//Fee rate of the batch transaction, expressed in satoshis per 1000 weight
-	//units (sat/kW).
+	// Fee rate of the batch transaction, expressed in satoshis per 1000 weight
+	// units (sat/kW).
 	FeeRateSatPerKw uint64 `protobuf:"varint,6,opt,name=fee_rate_sat_per_kw,json=feeRateSatPerKw,proto3" json:"fee_rate_sat_per_kw,omitempty"`
-	//
-	//Fee rebate in satoshis, offered if another batch participant wants to pay
-	//more fees for a faster confirmation.
+	// Fee rebate in satoshis, offered if another batch participant wants to pay
+	// more fees for a faster confirmation.
 	FeeRebateSat uint64 `protobuf:"varint,7,opt,name=fee_rebate_sat,json=feeRebateSat,proto3" json:"fee_rebate_sat,omitempty"`
-	//
-	//The 32 byte unique identifier of this batch.
+	// The 32 byte unique identifier of this batch.
 	BatchId []byte `protobuf:"bytes,8,opt,name=batch_id,json=batchId,proto3" json:"batch_id,omitempty"`
-	//
-	//The batch verification protocol version the server is using. Clients that
-	//don't support this version MUST return an `OrderMatchAccept` message with
-	//an empty list of orders so the batch can continue. The user should then be
-	//informed that a software update is required.
+	// The batch verification protocol version the server is using. Clients that
+	// don't support this version MUST return an `OrderMatchAccept` message with
+	// an empty list of orders so the batch can continue. The user should then be
+	// informed that a software update is required.
 	BatchVersion uint32 `protobuf:"varint,9,opt,name=batch_version,json=batchVersion,proto3" json:"batch_version,omitempty"`
-	//
-	//Maps the distinct lease duration markets to the orders that were matched
-	//within and the discovered market clearing price.
+	// Maps the distinct lease duration markets to the orders that were matched
+	// within and the discovered market clearing price.
 	MatchedMarkets map[uint32]*MatchedMarket `protobuf:"bytes,10,rep,name=matched_markets,json=matchedMarkets,proto3" json:"matched_markets,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	//
-	//The earliest absolute height in the chain in which the batch transaction can
-	//be found within. This will be used by traders to base off their absolute
-	//channel lease maturity height.
+	// The earliest absolute height in the chain in which the batch transaction can
+	// be found within. This will be used by traders to base off their absolute
+	// channel lease maturity height.
 	BatchHeightHint uint32 `protobuf:"varint,11,opt,name=batch_height_hint,json=batchHeightHint,proto3" json:"batch_height_hint,omitempty"`
 }
 
@@ -2650,11 +2570,9 @@ type TxOut struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The value of the transaction output in satoshis.
+	// The value of the transaction output in satoshis.
 	Value uint64 `protobuf:"varint,1,opt,name=value,proto3" json:"value,omitempty"`
-	//
-	//The public key script of the output.
+	// The public key script of the output.
 	PkScript []byte `protobuf:"bytes,2,opt,name=pk_script,json=pkScript,proto3" json:"pk_script,omitempty"`
 }
 
@@ -2709,19 +2627,16 @@ type OrderMatchSignBegin struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The 32 byte unique identifier of this batch.
+	// The 32 byte unique identifier of this batch.
 	BatchId []byte `protobuf:"bytes,1,opt,name=batch_id,json=batchId,proto3" json:"batch_id,omitempty"`
-	//
-	//A set of 66-byte nonces for each version 1 (Taproot enabled) account. The
-	//nonces can be used to produce a MuSig2 partial signature to spend the
-	//account using the key spend path, which is a MuSig2 combined key of the
-	//auctioneer key and the trader key.
+	// A set of 66-byte nonces for each version 1 (Taproot enabled) account. The
+	// nonces can be used to produce a MuSig2 partial signature to spend the
+	// account using the key spend path, which is a MuSig2 combined key of the
+	// auctioneer key and the trader key.
 	ServerNonces map[string][]byte `protobuf:"bytes,2,rep,name=server_nonces,json=serverNonces,proto3" json:"server_nonces,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	//
-	//The full list of UTXO information for each of the inputs being spent. This
-	//is required when spending one or more Taproot enabled (account version 1)
-	//outputs.
+	// The full list of UTXO information for each of the inputs being spent. This
+	// is required when spending one or more Taproot enabled (account version 1)
+	// outputs.
 	PrevOutputs []*TxOut `protobuf:"bytes,3,rep,name=prev_outputs,json=prevOutputs,proto3" json:"prev_outputs,omitempty"`
 }
 
@@ -2783,11 +2698,9 @@ type OrderMatchFinalize struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The unique identifier of the finalized batch.
+	// The unique identifier of the finalized batch.
 	BatchId []byte `protobuf:"bytes,1,opt,name=batch_id,json=batchId,proto3" json:"batch_id,omitempty"`
-	//
-	//The final transaction ID of the published batch transaction.
+	// The final transaction ID of the published batch transaction.
 	BatchTxid []byte `protobuf:"bytes,2,opt,name=batch_txid,json=batchTxid,proto3" json:"batch_txid,omitempty"`
 }
 
@@ -2842,23 +2755,19 @@ type SubscribeError struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The string representation of the subscription error.
+	// The string representation of the subscription error.
 	Error string `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`
-	//
-	//The error code of the subscription error.
+	// The error code of the subscription error.
 	ErrorCode SubscribeError_Error `protobuf:"varint,2,opt,name=error_code,json=errorCode,proto3,enum=poolrpc.SubscribeError_Error" json:"error_code,omitempty"`
-	//
-	//The trader's account key this error is referring to. This is not set if
-	//the error code is SERVER_SHUTDOWN as that error is only sent once per
-	//connection and not per individual subscription.
+	// The trader's account key this error is referring to. This is not set if
+	// the error code is SERVER_SHUTDOWN as that error is only sent once per
+	// connection and not per individual subscription.
 	TraderKey []byte `protobuf:"bytes,3,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
-	//
-	//The auctioneer's partial account information as it was stored when creating
-	//the reservation. This is only set if the error code is
-	//INCOMPLETE_ACCOUNT_RESERVATION. Only the fields value, expiry, trader_key,
-	//auctioneer_key, batch_key and height_hint will be set in that
-	//case.
+	// The auctioneer's partial account information as it was stored when creating
+	// the reservation. This is only set if the error code is
+	// INCOMPLETE_ACCOUNT_RESERVATION. Only the fields value, expiry, trader_key,
+	// auctioneer_key, batch_key and height_hint will be set in that
+	// case.
 	AccountReservation *AuctionAccount `protobuf:"bytes,4,opt,name=account_reservation,json=accountReservation,proto3" json:"account_reservation,omitempty"`
 }
 
@@ -2927,39 +2836,29 @@ type AuctionAccount struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The value of the account in satoshis. Must match the amount of the
-	//account_point output.
+	// The value of the account in satoshis. Must match the amount of the
+	// account_point output.
 	Value uint64 `protobuf:"varint,1,opt,name=value,proto3" json:"value,omitempty"`
-	//
-	//The block height at which the account should expire.
+	// The block height at which the account should expire.
 	Expiry uint32 `protobuf:"varint,2,opt,name=expiry,proto3" json:"expiry,omitempty"`
-	//
-	//The trader's account key.
+	// The trader's account key.
 	TraderKey []byte `protobuf:"bytes,3,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
-	//
-	//The long term auctioneer's account key.
+	// The long term auctioneer's account key.
 	AuctioneerKey []byte `protobuf:"bytes,4,opt,name=auctioneer_key,json=auctioneerKey,proto3" json:"auctioneer_key,omitempty"`
-	//
-	//The current batch key used to create the account output.
+	// The current batch key used to create the account output.
 	BatchKey []byte `protobuf:"bytes,5,opt,name=batch_key,json=batchKey,proto3" json:"batch_key,omitempty"`
-	//
-	//The current state of the account as the auctioneer sees it.
+	// The current state of the account as the auctioneer sees it.
 	State AuctionAccountState `protobuf:"varint,6,opt,name=state,proto3,enum=poolrpc.AuctionAccountState" json:"state,omitempty"`
-	//
-	//The block height of the last change to the account's output. Can be used to
-	//scan the chain for the output's spend state more efficiently.
+	// The block height of the last change to the account's output. Can be used to
+	// scan the chain for the output's spend state more efficiently.
 	HeightHint uint32 `protobuf:"varint,7,opt,name=height_hint,json=heightHint,proto3" json:"height_hint,omitempty"`
-	//
-	//Transaction output of the account. Depending on the state of the account,
-	//this output might have been spent.
+	// Transaction output of the account. Depending on the state of the account,
+	// this output might have been spent.
 	Outpoint *OutPoint `protobuf:"bytes,8,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
-	//
-	//The latest transaction of an account. This is only known by the auctioneer
-	//after the account has met its initial funding confirmation.
+	// The latest transaction of an account. This is only known by the auctioneer
+	// after the account has met its initial funding confirmation.
 	LatestTx []byte `protobuf:"bytes,9,opt,name=latest_tx,json=latestTx,proto3" json:"latest_tx,omitempty"`
-	//
-	//The account version. Will be set to 0 for legacy (non-taproot) accounts.
+	// The account version. Will be set to 0 for legacy (non-taproot) accounts.
 	Version uint32 `protobuf:"varint,10,opt,name=version,proto3" json:"version,omitempty"`
 }
 
@@ -3070,13 +2969,11 @@ type MatchedOrder struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The bids the trader's own order was matched against. This list is empty if
-	//the trader's order was a bid order itself.
+	// The bids the trader's own order was matched against. This list is empty if
+	// the trader's order was a bid order itself.
 	MatchedBids []*MatchedBid `protobuf:"bytes,1,rep,name=matched_bids,json=matchedBids,proto3" json:"matched_bids,omitempty"`
-	//
-	//The asks the trader's own order was matched against. This list is empty if
-	//the trader's order was an ask order itself.
+	// The asks the trader's own order was matched against. This list is empty if
+	// the trader's order was an ask order itself.
 	MatchedAsks []*MatchedAsk `protobuf:"bytes,2,rep,name=matched_asks,json=matchedAsks,proto3" json:"matched_asks,omitempty"`
 }
 
@@ -3131,11 +3028,9 @@ type MatchedAsk struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The ask order that was matched against.
+	// The ask order that was matched against.
 	Ask *ServerAsk `protobuf:"bytes,1,opt,name=ask,proto3" json:"ask,omitempty"`
-	//
-	//The number of units that were filled from/by this matched order.
+	// The number of units that were filled from/by this matched order.
 	UnitsFilled uint32 `protobuf:"varint,2,opt,name=units_filled,json=unitsFilled,proto3" json:"units_filled,omitempty"`
 }
 
@@ -3190,11 +3085,9 @@ type MatchedBid struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The ask order that was matched against.
+	// The ask order that was matched against.
 	Bid *ServerBid `protobuf:"bytes,1,opt,name=bid,proto3" json:"bid,omitempty"`
-	//
-	//The number of units that were filled from/by this matched order.
+	// The number of units that were filled from/by this matched order.
 	UnitsFilled uint32 `protobuf:"varint,2,opt,name=units_filled,json=unitsFilled,proto3" json:"units_filled,omitempty"`
 }
 
@@ -3249,32 +3142,26 @@ type AccountDiff struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The final balance of the account after the executed batch.
+	// The final balance of the account after the executed batch.
 	EndingBalance uint64 `protobuf:"varint,1,opt,name=ending_balance,json=endingBalance,proto3" json:"ending_balance,omitempty"`
-	//
-	//Depending on the amount of the final balance of the account, the remainder
-	//is either sent to a new on-chain output, extended off-chain or fully
-	//consumed by the batch and its fees.
+	// Depending on the amount of the final balance of the account, the remainder
+	// is either sent to a new on-chain output, extended off-chain or fully
+	// consumed by the batch and its fees.
 	EndingState AccountDiff_AccountState `protobuf:"varint,2,opt,name=ending_state,json=endingState,proto3,enum=poolrpc.AccountDiff_AccountState" json:"ending_state,omitempty"`
-	//
-	//If the account was re-created on-chain then the new account's index in the
-	//transaction is set here. If the account was fully spent or the remainder was
-	//extended off-chain then no new account outpoint is created and -1 is
-	//returned here.
+	// If the account was re-created on-chain then the new account's index in the
+	// transaction is set here. If the account was fully spent or the remainder was
+	// extended off-chain then no new account outpoint is created and -1 is
+	// returned here.
 	OutpointIndex int32 `protobuf:"varint,3,opt,name=outpoint_index,json=outpointIndex,proto3" json:"outpoint_index,omitempty"`
-	//
-	//The trader's account key this diff is referring to.
+	// The trader's account key this diff is referring to.
 	TraderKey []byte `protobuf:"bytes,4,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
-	//
-	//The new account expiry height used to verify the batch. If the batch is
-	//successfully executed the account must update its expiry height to this
-	//value.
+	// The new account expiry height used to verify the batch. If the batch is
+	// successfully executed the account must update its expiry height to this
+	// value.
 	NewExpiry uint32 `protobuf:"varint,5,opt,name=new_expiry,json=newExpiry,proto3" json:"new_expiry,omitempty"`
-	//
-	//The new account version used to verify the batch. If this is non-zero, it
-	//means the account was automatically upgraded to the given version during the
-	//batch execution.
+	// The new account version used to verify the batch. If this is non-zero, it
+	// means the account was automatically upgraded to the given version during the
+	// batch execution.
 	NewVersion uint32 `protobuf:"varint,6,opt,name=new_version,json=newVersion,proto3" json:"new_version,omitempty"`
 }
 
@@ -3357,41 +3244,31 @@ type ServerOrder struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The trader's account key of the account to use for the order.
+	// The trader's account key of the account to use for the order.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
-	//
-	//Fixed order rate in parts per billion.
+	// Fixed order rate in parts per billion.
 	RateFixed uint32 `protobuf:"varint,2,opt,name=rate_fixed,json=rateFixed,proto3" json:"rate_fixed,omitempty"`
-	//
-	//Order amount in satoshis.
+	// Order amount in satoshis.
 	Amt        uint64 `protobuf:"varint,3,opt,name=amt,proto3" json:"amt,omitempty"`
 	MinChanAmt uint64 `protobuf:"varint,4,opt,name=min_chan_amt,json=minChanAmt,proto3" json:"min_chan_amt,omitempty"`
-	//
-	//Order nonce of 32 byte length, acts as unique order identifier.
+	// Order nonce of 32 byte length, acts as unique order identifier.
 	OrderNonce []byte `protobuf:"bytes,6,opt,name=order_nonce,json=orderNonce,proto3" json:"order_nonce,omitempty"`
-	//
-	//Signature of the order's digest, signed with the user's account key. The
-	//signature must be fixed-size LN wire format encoded. Version 0 includes the
-	//fields version, rate_fixed, amt, max_batch_fee_rate_sat_per_kw and
-	//lease_duration_blocks in the order digest.
+	// Signature of the order's digest, signed with the user's account key. The
+	// signature must be fixed-size LN wire format encoded. Version 0 includes the
+	// fields version, rate_fixed, amt, max_batch_fee_rate_sat_per_kw and
+	// lease_duration_blocks in the order digest.
 	OrderSig []byte `protobuf:"bytes,7,opt,name=order_sig,json=orderSig,proto3" json:"order_sig,omitempty"`
-	//
-	//The multi signature key of the node creating the order, will be used for the
-	//target channel's funding TX 2-of-2 multi signature output.
+	// The multi signature key of the node creating the order, will be used for the
+	// target channel's funding TX 2-of-2 multi signature output.
 	MultiSigKey []byte `protobuf:"bytes,8,opt,name=multi_sig_key,json=multiSigKey,proto3" json:"multi_sig_key,omitempty"`
-	//
-	//The pubkey of the node creating the order.
+	// The pubkey of the node creating the order.
 	NodePub []byte `protobuf:"bytes,9,opt,name=node_pub,json=nodePub,proto3" json:"node_pub,omitempty"`
-	//
-	//The network addresses of the node creating the order.
+	// The network addresses of the node creating the order.
 	NodeAddr []*NodeAddress `protobuf:"bytes,10,rep,name=node_addr,json=nodeAddr,proto3" json:"node_addr,omitempty"`
-	//
-	//The type of the channel that should be opened.
+	// The type of the channel that should be opened.
 	ChannelType OrderChannelType `protobuf:"varint,12,opt,name=channel_type,json=channelType,proto3,enum=poolrpc.OrderChannelType" json:"channel_type,omitempty"`
-	//
-	//Maximum fee rate the trader is willing to pay for the batch transaction,
-	//expressed in satoshis per 1000 weight units (sat/kW).
+	// Maximum fee rate the trader is willing to pay for the batch transaction,
+	// expressed in satoshis per 1000 weight units (sat/kW).
 	MaxBatchFeeRateSatPerKw uint64 `protobuf:"varint,13,opt,name=max_batch_fee_rate_sat_per_kw,json=maxBatchFeeRateSatPerKw,proto3" json:"max_batch_fee_rate_sat_per_kw,omitempty"`
 	// List of nodes that will be allowed to match with our order. Incompatible
 	// with the `not_allowed_node_ids` field.
@@ -3548,40 +3425,32 @@ type ServerBid struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The common fields shared between both ask and bid order types.
+	// The common fields shared between both ask and bid order types.
 	Details *ServerOrder `protobuf:"bytes,1,opt,name=details,proto3" json:"details,omitempty"`
-	//
-	//Required number of blocks that a channel opened as a result of this bid
-	//should be kept open.
+	// Required number of blocks that a channel opened as a result of this bid
+	// should be kept open.
 	LeaseDurationBlocks uint32 `protobuf:"varint,2,opt,name=lease_duration_blocks,json=leaseDurationBlocks,proto3" json:"lease_duration_blocks,omitempty"`
-	//
-	//The version of the order format that is used. Will be increased once new
-	//features are added.
+	// The version of the order format that is used. Will be increased once new
+	// features are added.
 	Version uint32 `protobuf:"varint,4,opt,name=version,proto3" json:"version,omitempty"`
-	//
-	//The minimum node tier this order should be matched with. Only asks backed by
-	//a node this tier or higher will be eligible for matching with this bid.
+	// The minimum node tier this order should be matched with. Only asks backed by
+	// a node this tier or higher will be eligible for matching with this bid.
 	MinNodeTier NodeTier `protobuf:"varint,5,opt,name=min_node_tier,json=minNodeTier,proto3,enum=poolrpc.NodeTier" json:"min_node_tier,omitempty"`
-	//
-	//Give the incoming channel that results from this bid being matched an
-	//initial outbound balance by adding additional funds from the taker's account
-	//into the channel. As a simplification for the execution protocol and the
-	//channel reserve calculations the min_chan_amt must be set to the full order
-	//amount. For the inbound liquidity market the self_chan_balance can be at
-	//most the same as the order amount.
+	// Give the incoming channel that results from this bid being matched an
+	// initial outbound balance by adding additional funds from the taker's account
+	// into the channel. As a simplification for the execution protocol and the
+	// channel reserve calculations the min_chan_amt must be set to the full order
+	// amount. For the inbound liquidity market the self_chan_balance can be at
+	// most the same as the order amount.
 	SelfChanBalance uint64 `protobuf:"varint,6,opt,name=self_chan_balance,json=selfChanBalance,proto3" json:"self_chan_balance,omitempty"`
-	//
-	//If this bid order is meant to lease a channel for another node (which is
-	//dubbed a "sidecar channel") then this boolean needs to be set to true. The
-	//multi_sig_key, node_pub and node_addr fields of the order details must then
-	//correspond to the recipient node's details.
+	// If this bid order is meant to lease a channel for another node (which is
+	// dubbed a "sidecar channel") then this boolean needs to be set to true. The
+	// multi_sig_key, node_pub and node_addr fields of the order details must then
+	// correspond to the recipient node's details.
 	IsSidecarChannel bool `protobuf:"varint,7,opt,name=is_sidecar_channel,json=isSidecarChannel,proto3" json:"is_sidecar_channel,omitempty"`
-	//
-	//Signals if this bid is interested in an announced or unannounced channel.
+	// Signals if this bid is interested in an announced or unannounced channel.
 	UnannouncedChannel bool `protobuf:"varint,8,opt,name=unannounced_channel,json=unannouncedChannel,proto3" json:"unannounced_channel,omitempty"`
-	//
-	//Signals if this bid is interested in a zero conf channel or not.
+	// Signals if this bid is interested in a zero conf channel or not.
 	ZeroConfChannel bool `protobuf:"varint,9,opt,name=zero_conf_channel,json=zeroConfChannel,proto3" json:"zero_conf_channel,omitempty"`
 }
 
@@ -3678,23 +3547,18 @@ type ServerAsk struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The common fields shared between both ask and bid order types.
+	// The common fields shared between both ask and bid order types.
 	Details *ServerOrder `protobuf:"bytes,1,opt,name=details,proto3" json:"details,omitempty"`
-	//
-	//The number of blocks the liquidity provider is willing to provide the
-	//channel funds for.
+	// The number of blocks the liquidity provider is willing to provide the
+	// channel funds for.
 	LeaseDurationBlocks uint32 `protobuf:"varint,4,opt,name=lease_duration_blocks,json=leaseDurationBlocks,proto3" json:"lease_duration_blocks,omitempty"`
-	//
-	//The version of the order format that is used. Will be increased once new
-	//features are added.
+	// The version of the order format that is used. Will be increased once new
+	// features are added.
 	Version uint32 `protobuf:"varint,5,opt,name=version,proto3" json:"version,omitempty"`
-	//
-	//The constraints for selling the liquidity based on channel discoverability.
+	// The constraints for selling the liquidity based on channel discoverability.
 	AnnouncementConstraints ChannelAnnouncementConstraints `protobuf:"varint,6,opt,name=announcement_constraints,json=announcementConstraints,proto3,enum=poolrpc.ChannelAnnouncementConstraints" json:"announcement_constraints,omitempty"`
-	//
-	//The constraints for selling the liquidity based on the number of
-	//blocks before considering the channel confirmed.
+	// The constraints for selling the liquidity based on the number of
+	// blocks before considering the channel confirmed.
 	ConfirmationConstraints ChannelConfirmationConstraints `protobuf:"varint,7,opt,name=confirmation_constraints,json=confirmationConstraints,proto3,enum=poolrpc.ChannelConfirmationConstraints" json:"confirmation_constraints,omitempty"`
 }
 
@@ -3882,9 +3746,8 @@ type ServerInput struct {
 
 	// The outpoint that the input corresponds to.
 	Outpoint *OutPoint `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
-	//
-	//The signature script required by the input. This only applies to NP2WKH
-	//inputs.
+	// The signature script required by the input. This only applies to NP2WKH
+	// inputs.
 	SigScript []byte `protobuf:"bytes,2,opt,name=sig_script,json=sigScript,proto3" json:"sig_script,omitempty"`
 }
 
@@ -3996,31 +3859,26 @@ type ServerModifyAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The trader's account key of the account to be modified.
+	// The trader's account key of the account to be modified.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
-	//
-	//An additional set of inputs that can be included in the spending transaction
-	//of an account. These can be used to deposit more funds into an account.
-	//These must be under control of the backing lnd node's wallet.
+	// An additional set of inputs that can be included in the spending transaction
+	// of an account. These can be used to deposit more funds into an account.
+	// These must be under control of the backing lnd node's wallet.
 	NewInputs []*ServerInput `protobuf:"bytes,2,rep,name=new_inputs,json=newInputs,proto3" json:"new_inputs,omitempty"`
-	//
-	//An additional set of outputs that can be included in the spending
-	//transaction of an account. These can be used to withdraw funds from an
-	//account.
+	// An additional set of outputs that can be included in the spending
+	// transaction of an account. These can be used to withdraw funds from an
+	// account.
 	NewOutputs []*ServerOutput `protobuf:"bytes,3,rep,name=new_outputs,json=newOutputs,proto3" json:"new_outputs,omitempty"`
 	// The new parameters to apply for the account.
 	NewParams *ServerModifyAccountRequest_NewAccountParameters `protobuf:"bytes,4,opt,name=new_params,json=newParams,proto3" json:"new_params,omitempty"`
-	//
-	//A set of 66-byte nonces for each version 1 (Taproot enabled) account. The
-	//nonces can be used to produce a MuSig2 partial signature to spend the
-	//account using the key spend path, which is a MuSig2 combined key of the
-	//auctioneer key and the trader key.
+	// A set of 66-byte nonces for each version 1 (Taproot enabled) account. The
+	// nonces can be used to produce a MuSig2 partial signature to spend the
+	// account using the key spend path, which is a MuSig2 combined key of the
+	// auctioneer key and the trader key.
 	TraderNonces []byte `protobuf:"bytes,5,opt,name=trader_nonces,json=traderNonces,proto3" json:"trader_nonces,omitempty"`
-	//
-	//The full list of UTXO information for each of the inputs being spent. This
-	//is required when spending a Taproot enabled (account version 1) output or
-	//when adding additional Taproot inputs.
+	// The full list of UTXO information for each of the inputs being spent. This
+	// is required when spending a Taproot enabled (account version 1) output or
+	// when adding additional Taproot inputs.
 	PrevOutputs []*TxOut `protobuf:"bytes,6,rep,name=prev_outputs,json=prevOutputs,proto3" json:"prev_outputs,omitempty"`
 }
 
@@ -4103,19 +3961,17 @@ type ServerModifyAccountResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The auctioneer's signature that allows a trader to broadcast a transaction
-	//spending from an account output. For version 1 (Taproot enabled) accounts,
-	//this merely represents a partial MuSig2 signature that can be combined into
-	//a full signature by the trader daemon by adding its own partial signature. A
-	//set of nonces will be provided by the server (in case this is a v1 account)
-	//to allow finalizing the MuSig2 signing session.
+	// The auctioneer's signature that allows a trader to broadcast a transaction
+	// spending from an account output. For version 1 (Taproot enabled) accounts,
+	// this merely represents a partial MuSig2 signature that can be combined into
+	// a full signature by the trader daemon by adding its own partial signature. A
+	// set of nonces will be provided by the server (in case this is a v1 account)
+	// to allow finalizing the MuSig2 signing session.
 	AccountSig []byte `protobuf:"bytes,1,opt,name=account_sig,json=accountSig,proto3" json:"account_sig,omitempty"`
-	//
-	//An optional set of 66-byte nonces for a version 1 (Taproot enabled) account
-	//spend. The nonces can be used to produce a MuSig2 partial signature to spend
-	//the account using the key spend path, which is a MuSig2 combined key of the
-	//auctioneer key and the trader key.
+	// An optional set of 66-byte nonces for a version 1 (Taproot enabled) account
+	// spend. The nonces can be used to produce a MuSig2 partial signature to spend
+	// the account using the key spend path, which is a MuSig2 combined key of the
+	// auctioneer key and the trader key.
 	ServerNonces []byte `protobuf:"bytes,2,opt,name=server_nonces,json=serverNonces,proto3" json:"server_nonces,omitempty"`
 }
 
@@ -4217,13 +4073,11 @@ type ServerOrderStateResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The state the order currently is in.
+	// The state the order currently is in.
 	State OrderState `protobuf:"varint,1,opt,name=state,proto3,enum=poolrpc.OrderState" json:"state,omitempty"`
-	//
-	//The number of currently unfilled units of this order. This will be equal to
-	//the total amount of units until the order has reached the state PARTIAL_FILL
-	//or EXECUTED.
+	// The number of currently unfilled units of this order. This will be equal to
+	// the total amount of units until the order has reached the state PARTIAL_FILL
+	// or EXECUTED.
 	UnitsUnfulfilled uint32 `protobuf:"varint,2,opt,name=units_unfulfilled,json=unitsUnfulfilled,proto3" json:"units_unfulfilled,omitempty"`
 }
 
@@ -4316,39 +4170,31 @@ type TermsResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The maximum account size in satoshis currently allowed by the auctioneer.
+	// The maximum account size in satoshis currently allowed by the auctioneer.
 	MaxAccountValue uint64 `protobuf:"varint,1,opt,name=max_account_value,json=maxAccountValue,proto3" json:"max_account_value,omitempty"`
-	//
-	//Deprecated, use explicit order duration from lease_duration_buckets.
+	// Deprecated, use explicit order duration from lease_duration_buckets.
 	//
 	// Deprecated: Do not use.
 	MaxOrderDurationBlocks uint32 `protobuf:"varint,2,opt,name=max_order_duration_blocks,json=maxOrderDurationBlocks,proto3" json:"max_order_duration_blocks,omitempty"`
-	//
-	//The execution fee charged per matched order.
+	// The execution fee charged per matched order.
 	ExecutionFee *ExecutionFee `protobuf:"bytes,3,opt,name=execution_fee,json=executionFee,proto3" json:"execution_fee,omitempty"`
-	//
-	//Deprecated, use lease_duration_buckets.
+	// Deprecated, use lease_duration_buckets.
 	//
 	// Deprecated: Do not use.
 	LeaseDurations map[uint32]bool `protobuf:"bytes,4,rep,name=lease_durations,json=leaseDurations,proto3" json:"lease_durations,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
 	// The confirmation target to use for fee estimation of the next batch.
 	NextBatchConfTarget uint32 `protobuf:"varint,5,opt,name=next_batch_conf_target,json=nextBatchConfTarget,proto3" json:"next_batch_conf_target,omitempty"`
-	//
-	//The fee rate, in satoshis per kiloweight, estimated to use for the next
-	//batch.
+	// The fee rate, in satoshis per kiloweight, estimated to use for the next
+	// batch.
 	NextBatchFeeRateSatPerKw uint64 `protobuf:"varint,6,opt,name=next_batch_fee_rate_sat_per_kw,json=nextBatchFeeRateSatPerKw,proto3" json:"next_batch_fee_rate_sat_per_kw,omitempty"`
-	//
-	//The absolute unix timestamp at which the auctioneer will attempt to clear
-	//the next batch.
+	// The absolute unix timestamp at which the auctioneer will attempt to clear
+	// the next batch.
 	NextBatchClearTimestamp uint64 `protobuf:"varint,7,opt,name=next_batch_clear_timestamp,json=nextBatchClearTimestamp,proto3" json:"next_batch_clear_timestamp,omitempty"`
-	//
-	//The set of lease durations the market is currently accepting and the state
-	//the duration buckets currently are in.
+	// The set of lease durations the market is currently accepting and the state
+	// the duration buckets currently are in.
 	LeaseDurationBuckets map[uint32]DurationBucketState `protobuf:"bytes,8,rep,name=lease_duration_buckets,json=leaseDurationBuckets,proto3" json:"lease_duration_buckets,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3,enum=poolrpc.DurationBucketState"`
-	//
-	//The value used by the auctioneer to determine if an account expiry height
-	//needs to be extended after participating in a batch and for how long.
+	// The value used by the auctioneer to determine if an account expiry height
+	// needs to be extended after participating in a batch and for how long.
 	AutoRenewExtensionBlocks uint32 `protobuf:"varint,9,opt,name=auto_renew_extension_blocks,json=autoRenewExtensionBlocks,proto3" json:"auto_renew_extension_blocks,omitempty"`
 }
 
@@ -4456,9 +4302,8 @@ type RelevantBatchRequest struct {
 
 	// The unique identifier of the batch.
 	Id []byte `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	//
-	//The set of accounts the trader is interested in retrieving information
-	//for within the batch. Each account is identified by its trader key.
+	// The set of accounts the trader is interested in retrieving information
+	// for within the batch. Each account is identified by its trader key.
 	Accounts [][]byte `protobuf:"bytes,2,rep,name=accounts,proto3" json:"accounts,omitempty"`
 }
 
@@ -4517,17 +4362,14 @@ type RelevantBatch struct {
 	Version uint32 `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
 	// The unique identifier of the batch.
 	Id []byte `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
-	//
-	//The set of modifications that should be applied to the requested accounts as
-	//a result of this batch.
+	// The set of modifications that should be applied to the requested accounts as
+	// a result of this batch.
 	ChargedAccounts []*AccountDiff `protobuf:"bytes,3,rep,name=charged_accounts,json=chargedAccounts,proto3" json:"charged_accounts,omitempty"`
-	//
-	//Deprecated, use matched_markets.
+	// Deprecated, use matched_markets.
 	//
 	// Deprecated: Do not use.
 	MatchedOrders map[string]*MatchedOrder `protobuf:"bytes,4,rep,name=matched_orders,json=matchedOrders,proto3" json:"matched_orders,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	//
-	//Deprecated, use matched_markets.
+	// Deprecated, use matched_markets.
 	//
 	// Deprecated: Do not use.
 	ClearingPriceRate uint32 `protobuf:"varint,5,opt,name=clearing_price_rate,json=clearingPriceRate,proto3" json:"clearing_price_rate,omitempty"`
@@ -4535,15 +4377,13 @@ type RelevantBatch struct {
 	ExecutionFee *ExecutionFee `protobuf:"bytes,6,opt,name=execution_fee,json=executionFee,proto3" json:"execution_fee,omitempty"`
 	// The batch transaction including all witness data.
 	Transaction []byte `protobuf:"bytes,7,opt,name=transaction,proto3" json:"transaction,omitempty"`
-	//
-	//Fee rate of the batch transaction, expressed in satoshis per 1000 weight
-	//units (sat/kW).
+	// Fee rate of the batch transaction, expressed in satoshis per 1000 weight
+	// units (sat/kW).
 	FeeRateSatPerKw uint64 `protobuf:"varint,8,opt,name=fee_rate_sat_per_kw,json=feeRateSatPerKw,proto3" json:"fee_rate_sat_per_kw,omitempty"`
 	// The unix timestamp in nanoseconds the batch was made.
 	CreationTimestampNs uint64 `protobuf:"varint,9,opt,name=creation_timestamp_ns,json=creationTimestampNs,proto3" json:"creation_timestamp_ns,omitempty"`
-	//
-	//Maps the distinct lease duration markets to the orders that were matched
-	//within and the discovered market clearing price.
+	// Maps the distinct lease duration markets to the orders that were matched
+	// within and the discovered market clearing price.
 	MatchedMarkets map[uint32]*MatchedMarket `protobuf:"bytes,10,rep,name=matched_markets,json=matchedMarkets,proto3" json:"matched_markets,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -4656,11 +4496,9 @@ type ExecutionFee struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The base fee in satoshis charged per order, regardless of the matched size.
+	// The base fee in satoshis charged per order, regardless of the matched size.
 	BaseFee uint64 `protobuf:"varint,1,opt,name=base_fee,json=baseFee,proto3" json:"base_fee,omitempty"`
-	//
-	//The fee rate in parts per million.
+	// The fee rate in parts per million.
 	FeeRate uint64 `protobuf:"varint,2,opt,name=fee_rate,json=feeRate,proto3" json:"fee_rate,omitempty"`
 }
 
@@ -4770,11 +4608,9 @@ type OutPoint struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//Raw bytes representing the transaction id.
+	// Raw bytes representing the transaction id.
 	Txid []byte `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
-	//
-	//The index of the output on the transaction.
+	// The index of the output on the transaction.
 	OutputIndex uint32 `protobuf:"varint,2,opt,name=output_index,json=outputIndex,proto3" json:"output_index,omitempty"`
 }
 
@@ -5111,12 +4947,10 @@ type MatchedMarketSnapshot struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The set of all orders matched in the batch.
+	// The set of all orders matched in the batch.
 	MatchedOrders []*MatchedOrderSnapshot `protobuf:"bytes,1,rep,name=matched_orders,json=matchedOrders,proto3" json:"matched_orders,omitempty"`
-	//
-	//The uniform clearing price rate in parts per billion that was used for this
-	//batch.
+	// The uniform clearing price rate in parts per billion that was used for this
+	// batch.
 	ClearingPriceRate uint32 `protobuf:"varint,2,opt,name=clearing_price_rate,json=clearingPriceRate,proto3" json:"clearing_price_rate,omitempty"`
 }
 
@@ -5177,13 +5011,11 @@ type BatchSnapshotResponse struct {
 	BatchId []byte `protobuf:"bytes,2,opt,name=batch_id,json=batchId,proto3" json:"batch_id,omitempty"`
 	// The unique identifier of the prior batch.
 	PrevBatchId []byte `protobuf:"bytes,3,opt,name=prev_batch_id,json=prevBatchId,proto3" json:"prev_batch_id,omitempty"`
-	//
-	//Deprecated, use matched_markets.
+	// Deprecated, use matched_markets.
 	//
 	// Deprecated: Do not use.
 	ClearingPriceRate uint32 `protobuf:"varint,4,opt,name=clearing_price_rate,json=clearingPriceRate,proto3" json:"clearing_price_rate,omitempty"`
-	//
-	//Deprecated, use matched_markets.
+	// Deprecated, use matched_markets.
 	//
 	// Deprecated: Do not use.
 	MatchedOrders []*MatchedOrderSnapshot `protobuf:"bytes,5,rep,name=matched_orders,json=matchedOrders,proto3" json:"matched_orders,omitempty"`
@@ -5195,9 +5027,8 @@ type BatchSnapshotResponse struct {
 	BatchTxFeeRateSatPerKw uint64 `protobuf:"varint,8,opt,name=batch_tx_fee_rate_sat_per_kw,json=batchTxFeeRateSatPerKw,proto3" json:"batch_tx_fee_rate_sat_per_kw,omitempty"`
 	// The unix timestamp in nanoseconds the batch was made.
 	CreationTimestampNs uint64 `protobuf:"varint,9,opt,name=creation_timestamp_ns,json=creationTimestampNs,proto3" json:"creation_timestamp_ns,omitempty"`
-	//
-	//Maps the distinct lease duration markets to the orders that were matched
-	//within and the discovered market clearing price.
+	// Maps the distinct lease duration markets to the orders that were matched
+	// within and the discovered market clearing price.
 	MatchedMarkets map[uint32]*MatchedMarketSnapshot `protobuf:"bytes,10,rep,name=matched_markets,json=matchedMarkets,proto3" json:"matched_markets,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -5463,14 +5294,12 @@ type BatchSnapshotsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The unique identifier of the first batch to return, encoded as a compressed
-	//pubkey. This represents the newest/most current batch to fetch. If this is
-	//empty or a zero batch ID, the most recent finalized batch is used as the
-	//starting point to go back from.
+	// The unique identifier of the first batch to return, encoded as a compressed
+	// pubkey. This represents the newest/most current batch to fetch. If this is
+	// empty or a zero batch ID, the most recent finalized batch is used as the
+	// starting point to go back from.
 	StartBatchId []byte `protobuf:"bytes,1,opt,name=start_batch_id,json=startBatchId,proto3" json:"start_batch_id,omitempty"`
-	//
-	//The number of batches to return at most, including the start batch.
+	// The number of batches to return at most, including the start batch.
 	NumBatchesBack uint32 `protobuf:"varint,2,opt,name=num_batches_back,json=numBatchesBack,proto3" json:"num_batches_back,omitempty"`
 }
 
@@ -5615,13 +5444,11 @@ type MarketInfo struct {
 	NumAsks []*MarketInfo_TierValue `protobuf:"bytes,1,rep,name=num_asks,json=numAsks,proto3" json:"num_asks,omitempty"`
 	// The number of open/pending bid orders per node tier.
 	NumBids []*MarketInfo_TierValue `protobuf:"bytes,2,rep,name=num_bids,json=numBids,proto3" json:"num_bids,omitempty"`
-	//
-	//The total number of open/unmatched units in open/pending ask orders per node
-	//tier.
+	// The total number of open/unmatched units in open/pending ask orders per node
+	// tier.
 	AskOpenInterestUnits []*MarketInfo_TierValue `protobuf:"bytes,3,rep,name=ask_open_interest_units,json=askOpenInterestUnits,proto3" json:"ask_open_interest_units,omitempty"`
-	//
-	//The total number of open/unmatched units in open/pending bid orders per node
-	//tier.
+	// The total number of open/unmatched units in open/pending bid orders per node
+	// tier.
 	BidOpenInterestUnits []*MarketInfo_TierValue `protobuf:"bytes,4,rep,name=bid_open_interest_units,json=bidOpenInterestUnits,proto3" json:"bid_open_interest_units,omitempty"`
 }
 

--- a/auctioneerrpc/hashmail.pb.go
+++ b/auctioneerrpc/hashmail.pb.go
@@ -87,9 +87,8 @@ type SidecarAuth struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//A valid sidecar ticket that has been signed (offered) by a Pool account in
-	//the active state.
+	// A valid sidecar ticket that has been signed (offered) by a Pool account in
+	// the active state.
 	Ticket string `protobuf:"bytes,1,opt,name=ticket,proto3" json:"ticket,omitempty"`
 }
 
@@ -140,6 +139,7 @@ type CipherBoxAuth struct {
 	// A description of the stream one is attempting to initialize.
 	Desc *CipherBoxDesc `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc,omitempty"`
 	// Types that are assignable to Auth:
+	//
 	//	*CipherBoxAuth_AcctAuth
 	//	*CipherBoxAuth_SidecarAuth
 	Auth isCipherBoxAuth_Auth `protobuf_oneof:"auth"`
@@ -388,6 +388,7 @@ type CipherInitResp struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Resp:
+	//
 	//	*CipherInitResp_Success
 	//	*CipherInitResp_Challenge
 	//	*CipherInitResp_Error
@@ -459,23 +460,20 @@ type isCipherInitResp_Resp interface {
 }
 
 type CipherInitResp_Success struct {
-	//
-	//CipherSuccess is returned if the initialization of the cipher box was
-	//successful.
+	// CipherSuccess is returned if the initialization of the cipher box was
+	// successful.
 	Success *CipherSuccess `protobuf:"bytes,1,opt,name=success,proto3,oneof"`
 }
 
 type CipherInitResp_Challenge struct {
-	//
-	//CipherChallenge is returned if the authentication mechanism was revoked
-	//or needs to be refreshed.
+	// CipherChallenge is returned if the authentication mechanism was revoked
+	// or needs to be refreshed.
 	Challenge *CipherChallenge `protobuf:"bytes,2,opt,name=challenge,proto3,oneof"`
 }
 
 type CipherInitResp_Error struct {
-	//
-	//CipherError is returned if the authentication mechanism failed to
-	//validate.
+	// CipherError is returned if the authentication mechanism failed to
+	// validate.
 	Error *CipherError `protobuf:"bytes,3,opt,name=error,proto3,oneof"`
 }
 

--- a/auctioneerrpc/hashmail_grpc.pb.go
+++ b/auctioneerrpc/hashmail_grpc.pb.go
@@ -18,26 +18,22 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type HashMailClient interface {
-	//
-	//NewCipherBox creates a new cipher box pipe/stream given a valid
-	//authentication mechanism. If the authentication mechanism has been revoked,
-	//or needs to be changed, then a CipherChallenge message is returned.
-	//Otherwise the method will either be accepted or rejected.
+	// NewCipherBox creates a new cipher box pipe/stream given a valid
+	// authentication mechanism. If the authentication mechanism has been revoked,
+	// or needs to be changed, then a CipherChallenge message is returned.
+	// Otherwise the method will either be accepted or rejected.
 	NewCipherBox(ctx context.Context, in *CipherBoxAuth, opts ...grpc.CallOption) (*CipherInitResp, error)
-	//
-	//DelCipherBox attempts to tear down an existing cipher box pipe. The same
-	//authentication mechanism used to initially create the stream MUST be
-	//specified.
+	// DelCipherBox attempts to tear down an existing cipher box pipe. The same
+	// authentication mechanism used to initially create the stream MUST be
+	// specified.
 	DelCipherBox(ctx context.Context, in *CipherBoxAuth, opts ...grpc.CallOption) (*DelCipherBoxResp, error)
-	//
-	//SendStream opens up the write side of the passed CipherBox pipe. Writes
-	//will be non-blocking up to the buffer size of the pipe. Beyond that writes
-	//will block until completed.
+	// SendStream opens up the write side of the passed CipherBox pipe. Writes
+	// will be non-blocking up to the buffer size of the pipe. Beyond that writes
+	// will block until completed.
 	SendStream(ctx context.Context, opts ...grpc.CallOption) (HashMail_SendStreamClient, error)
-	//
-	//RecvStream opens up the read side of the passed CipherBox pipe. This method
-	//will block until a full message has been read as this is a message based
-	//pipe/stream abstraction.
+	// RecvStream opens up the read side of the passed CipherBox pipe. This method
+	// will block until a full message has been read as this is a message based
+	// pipe/stream abstraction.
 	RecvStream(ctx context.Context, in *CipherBoxDesc, opts ...grpc.CallOption) (HashMail_RecvStreamClient, error)
 }
 
@@ -137,26 +133,22 @@ func (x *hashMailRecvStreamClient) Recv() (*CipherBox, error) {
 // All implementations must embed UnimplementedHashMailServer
 // for forward compatibility
 type HashMailServer interface {
-	//
-	//NewCipherBox creates a new cipher box pipe/stream given a valid
-	//authentication mechanism. If the authentication mechanism has been revoked,
-	//or needs to be changed, then a CipherChallenge message is returned.
-	//Otherwise the method will either be accepted or rejected.
+	// NewCipherBox creates a new cipher box pipe/stream given a valid
+	// authentication mechanism. If the authentication mechanism has been revoked,
+	// or needs to be changed, then a CipherChallenge message is returned.
+	// Otherwise the method will either be accepted or rejected.
 	NewCipherBox(context.Context, *CipherBoxAuth) (*CipherInitResp, error)
-	//
-	//DelCipherBox attempts to tear down an existing cipher box pipe. The same
-	//authentication mechanism used to initially create the stream MUST be
-	//specified.
+	// DelCipherBox attempts to tear down an existing cipher box pipe. The same
+	// authentication mechanism used to initially create the stream MUST be
+	// specified.
 	DelCipherBox(context.Context, *CipherBoxAuth) (*DelCipherBoxResp, error)
-	//
-	//SendStream opens up the write side of the passed CipherBox pipe. Writes
-	//will be non-blocking up to the buffer size of the pipe. Beyond that writes
-	//will block until completed.
+	// SendStream opens up the write side of the passed CipherBox pipe. Writes
+	// will be non-blocking up to the buffer size of the pipe. Beyond that writes
+	// will block until completed.
 	SendStream(HashMail_SendStreamServer) error
-	//
-	//RecvStream opens up the read side of the passed CipherBox pipe. This method
-	//will block until a full message has been read as this is a message based
-	//pipe/stream abstraction.
+	// RecvStream opens up the read side of the passed CipherBox pipe. This method
+	// will block until a full message has been read as this is a message based
+	// pipe/stream abstraction.
 	RecvStream(*CipherBoxDesc, HashMail_RecvStreamServer) error
 	mustEmbedUnimplementedHashMailServer()
 }

--- a/clientdb/batch_snapshot.go
+++ b/clientdb/batch_snapshot.go
@@ -15,25 +15,26 @@ import (
 )
 
 // batch-snapshot-bucket
-//         |
-//         |-- batch-snapshot-pending-key: <batch snapshot>
-//         |
-//         |-- batch-snapshot-seq-bucket
-//         |              |
-//         |              |-- <sequence num>
-//         |              |        |
-//         |              |        |-- batch-snapshot-batch: <batch snapshot>
-//         |              |
-//         |              |-- <sequence num>
-//         |              |        |
-//         |             ...      ...
-//         |
-//         |-- batch-snapshot-batchid-index-bucket
-//                       |
-//                       |-- <batch id>: <sequence-num>
-//                       |-- <batch id>: <sequence-num>
-//                       |
-//                      ...
+//
+//	|
+//	|-- batch-snapshot-pending-key: <batch snapshot>
+//	|
+//	|-- batch-snapshot-seq-bucket
+//	|              |
+//	|              |-- <sequence num>
+//	|              |        |
+//	|              |        |-- batch-snapshot-batch: <batch snapshot>
+//	|              |
+//	|              |-- <sequence num>
+//	|              |        |
+//	|             ...      ...
+//	|
+//	|-- batch-snapshot-batchid-index-bucket
+//	              |
+//	              |-- <batch id>: <sequence-num>
+//	              |-- <batch id>: <sequence-num>
+//	              |
+//	             ...
 var (
 	// batchSnapshotBucketKey is the top level bucket where we'll find
 	// snapshot information about all batches we have participated in.

--- a/gen/Dockerfile
+++ b/gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-bullseye
+FROM golang:1.19.4-bullseye
 
 RUN go install github.com/golang/mock/mockgen@73266f9366fcf2ccef0b880618e5a9266e4136f4
 

--- a/poolrpc/Dockerfile
+++ b/poolrpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-buster
+FROM golang:1.19.4-buster
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/poolrpc/trader.pb.go
+++ b/poolrpc/trader.pb.go
@@ -24,17 +24,14 @@ const (
 type AccountVersion int32
 
 const (
-	//
-	//Let the version of lnd decide. If a version of lnd >= 0.15.0-beta is
-	//detected then a Taproot account is created. For earlier versions a legacy
-	//account is created.
+	// Let the version of lnd decide. If a version of lnd >= 0.15.0-beta is
+	// detected then a Taproot account is created. For earlier versions a legacy
+	// account is created.
 	AccountVersion_ACCOUNT_VERSION_LND_DEPENDENT AccountVersion = 0
-	//
-	//A legacy SegWit v0 p2wsh account with a single script.
+	// A legacy SegWit v0 p2wsh account with a single script.
 	AccountVersion_ACCOUNT_VERSION_LEGACY AccountVersion = 1
-	//
-	//A Taproot enabled account with MuSig2 combined internal key and the expiry
-	//script as a single tap script leaf.
+	// A Taproot enabled account with MuSig2 combined internal key and the expiry
+	// script as a single tap script leaf.
 	AccountVersion_ACCOUNT_VERSION_TAPROOT AccountVersion = 2
 )
 
@@ -84,32 +81,27 @@ type AccountState int32
 const (
 	// The state of an account when it is pending its confirmation on-chain.
 	AccountState_PENDING_OPEN AccountState = 0
-	//
-	//The state of an account when it has undergone an update on-chain either as
-	//part of a matched order or a trader modification and it is pending its
-	//confirmation on-chain.
+	// The state of an account when it has undergone an update on-chain either as
+	// part of a matched order or a trader modification and it is pending its
+	// confirmation on-chain.
 	AccountState_PENDING_UPDATE AccountState = 1
 	// The state of an account once it has confirmed on-chain.
 	AccountState_OPEN AccountState = 2
-	//
-	//The state of an account once its expiration has been reached and its closing
-	//transaction has confirmed.
+	// The state of an account once its expiration has been reached and its closing
+	// transaction has confirmed.
 	AccountState_EXPIRED AccountState = 3
-	//
-	//The state of an account when we're waiting for the closing transaction of
-	//an account to confirm that required cooperation with the auctioneer.
+	// The state of an account when we're waiting for the closing transaction of
+	// an account to confirm that required cooperation with the auctioneer.
 	AccountState_PENDING_CLOSED AccountState = 4
 	// The state of an account once its closing transaction has confirmed.
 	AccountState_CLOSED AccountState = 5
-	//
-	//The state of an account that indicates that the account was attempted to be
-	//recovered but failed because the opening transaction wasn't found by lnd.
-	//This could be because it was never published or it never confirmed. Then the
-	//funds are SAFU and the account can be considered to never have been opened
-	//in the first place.
+	// The state of an account that indicates that the account was attempted to be
+	// recovered but failed because the opening transaction wasn't found by lnd.
+	// This could be because it was never published or it never confirmed. Then the
+	// funds are SAFU and the account can be considered to never have been opened
+	// in the first place.
 	AccountState_RECOVERY_FAILED AccountState = 6
-	//
-	//The account has recently participated in a batch and is not yet confirmed.
+	// The account has recently participated in a batch and is not yet confirmed.
 	AccountState_PENDING_BATCH AccountState = 7
 )
 
@@ -167,24 +159,19 @@ func (AccountState) EnumDescriptor() ([]byte, []int) {
 type MatchState int32
 
 const (
-	//
-	//The OrderMatchPrepare message from the auctioneer was received initially.
+	// The OrderMatchPrepare message from the auctioneer was received initially.
 	MatchState_PREPARE MatchState = 0
-	//
-	//The OrderMatchPrepare message from the auctioneer was processed successfully
-	//and the batch was accepted.
+	// The OrderMatchPrepare message from the auctioneer was processed successfully
+	// and the batch was accepted.
 	MatchState_ACCEPTED MatchState = 1
-	//
-	//The order was rejected by the trader daemon, either as an answer to a
-	//OrderMatchSignBegin or OrderMatchFinalize message from the auctioneer.
+	// The order was rejected by the trader daemon, either as an answer to a
+	// OrderMatchSignBegin or OrderMatchFinalize message from the auctioneer.
 	MatchState_REJECTED MatchState = 2
-	//
-	//The OrderMatchSignBegin message from the auctioneer was processed
-	//successfully.
+	// The OrderMatchSignBegin message from the auctioneer was processed
+	// successfully.
 	MatchState_SIGNED MatchState = 3
-	//
-	//The OrderMatchFinalize message from the auctioneer was processed
-	//successfully.
+	// The OrderMatchFinalize message from the auctioneer was processed
+	// successfully.
 	MatchState_FINALIZED MatchState = 4
 )
 
@@ -238,31 +225,26 @@ type MatchRejectReason int32
 const (
 	// No reject occurred, this is the default value.
 	MatchRejectReason_NONE MatchRejectReason = 0
-	//
-	//The client didn't come up with the same result as the server and is
-	//rejecting the batch because of that.
+	// The client didn't come up with the same result as the server and is
+	// rejecting the batch because of that.
 	MatchRejectReason_SERVER_MISBEHAVIOR MatchRejectReason = 1
-	//
-	//The client doesn't support the current batch verification version the
-	//server is using.
+	// The client doesn't support the current batch verification version the
+	// server is using.
 	MatchRejectReason_BATCH_VERSION_MISMATCH MatchRejectReason = 2
-	//
-	//The client rejects some of the orders, not the full batch. This reason is
-	//set on matches for orders that were in the same batch as partial reject ones
-	//but were not themselves rejected.
+	// The client rejects some of the orders, not the full batch. This reason is
+	// set on matches for orders that were in the same batch as partial reject ones
+	// but were not themselves rejected.
 	MatchRejectReason_PARTIAL_REJECT_COLLATERAL MatchRejectReason = 3
-	//
-	//The trader's client has a preference to only match orders with peers it
-	//doesn't already have channels with. The order that is rejected with this
-	//reason type comes from a peer that the trader already has channels with.
+	// The trader's client has a preference to only match orders with peers it
+	// doesn't already have channels with. The order that is rejected with this
+	// reason type comes from a peer that the trader already has channels with.
 	MatchRejectReason_PARTIAL_REJECT_DUPLICATE_PEER MatchRejectReason = 4
-	//
-	//The trader's client couldn't connect to the remote node of the matched
-	//order or the channel funding could not be initialized for another
-	//reason. This could also be the rejecting node's fault if their
-	//connection is not stable. Using this code can have a negative impact on
-	//the reputation score of both nodes, depending on the number of errors
-	//recorded.
+	// The trader's client couldn't connect to the remote node of the matched
+	// order or the channel funding could not be initialized for another
+	// reason. This could also be the rejecting node's fault if their
+	// connection is not stable. Using this code can have a negative impact on
+	// the reputation score of both nodes, depending on the number of errors
+	// recorded.
 	MatchRejectReason_PARTIAL_REJECT_CHANNEL_FUNDING_FAILED MatchRejectReason = 5
 )
 
@@ -320,22 +302,22 @@ type InitAccountRequest struct {
 
 	AccountValue uint64 `protobuf:"varint,1,opt,name=account_value,json=accountValue,proto3" json:"account_value,omitempty"`
 	// Types that are assignable to AccountExpiry:
+	//
 	//	*InitAccountRequest_AbsoluteHeight
 	//	*InitAccountRequest_RelativeHeight
 	AccountExpiry isInitAccountRequest_AccountExpiry `protobuf_oneof:"account_expiry"`
 	// Types that are assignable to Fees:
+	//
 	//	*InitAccountRequest_ConfTarget
 	//	*InitAccountRequest_FeeRateSatPerKw
 	Fees isInitAccountRequest_Fees `protobuf_oneof:"fees"`
-	//
-	//An optional identification string that will be appended to the user agent
-	//string sent to the server to give information about the usage of pool. This
-	//initiator part is meant for user interfaces to add their name to give the
-	//full picture of the binary used (poold, LiT) and the method used for opening
-	//the account (pool CLI, LiT UI, other 3rd party UI).
+	// An optional identification string that will be appended to the user agent
+	// string sent to the server to give information about the usage of pool. This
+	// initiator part is meant for user interfaces to add their name to give the
+	// full picture of the binary used (poold, LiT) and the method used for opening
+	// the account (pool CLI, LiT UI, other 3rd party UI).
 	Initiator string `protobuf:"bytes,5,opt,name=initiator,proto3" json:"initiator,omitempty"`
-	//
-	//The version of account to create.
+	// The version of account to create.
 	Version AccountVersion `protobuf:"varint,7,opt,name=version,proto3,enum=poolrpc.AccountVersion" json:"version,omitempty"`
 }
 
@@ -455,15 +437,13 @@ type isInitAccountRequest_Fees interface {
 }
 
 type InitAccountRequest_ConfTarget struct {
-	//
-	//The target number of blocks that the transaction should be confirmed in.
+	// The target number of blocks that the transaction should be confirmed in.
 	ConfTarget uint32 `protobuf:"varint,4,opt,name=conf_target,json=confTarget,proto3,oneof"`
 }
 
 type InitAccountRequest_FeeRateSatPerKw struct {
-	//
-	//The fee rate, in satoshis per kw, to use for the initial funding
-	//transaction.
+	// The fee rate, in satoshis per kw, to use for the initial funding
+	// transaction.
 	FeeRateSatPerKw uint64 `protobuf:"varint,6,opt,name=fee_rate_sat_per_kw,json=feeRateSatPerKw,proto3,oneof"`
 }
 
@@ -478,6 +458,7 @@ type QuoteAccountRequest struct {
 
 	AccountValue uint64 `protobuf:"varint,1,opt,name=account_value,json=accountValue,proto3" json:"account_value,omitempty"`
 	// Types that are assignable to Fees:
+	//
 	//	*QuoteAccountRequest_ConfTarget
 	Fees isQuoteAccountRequest_Fees `protobuf_oneof:"fees"`
 }
@@ -540,8 +521,7 @@ type isQuoteAccountRequest_Fees interface {
 }
 
 type QuoteAccountRequest_ConfTarget struct {
-	//
-	//The target number of blocks that the transaction should be confirmed in.
+	// The target number of blocks that the transaction should be confirmed in.
 	ConfTarget uint32 `protobuf:"varint,2,opt,name=conf_target,json=confTarget,proto3,oneof"`
 }
 
@@ -607,8 +587,7 @@ type ListAccountsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//Only list accounts that are still active.
+	// Only list accounts that are still active.
 	ActiveOnly bool `protobuf:"varint,1,opt,name=active_only,json=activeOnly,proto3" json:"active_only,omitempty"`
 }
 
@@ -763,6 +742,7 @@ type OutputWithFee struct {
 	// The address corresponding to the output.
 	Address string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	// Types that are assignable to Fees:
+	//
 	//	*OutputWithFee_ConfTarget
 	//	*OutputWithFee_FeeRateSatPerKw
 	Fees isOutputWithFee_Fees `protobuf_oneof:"fees"`
@@ -833,14 +813,12 @@ type isOutputWithFee_Fees interface {
 }
 
 type OutputWithFee_ConfTarget struct {
-	//
-	//The target number of blocks that the transaction should be confirmed in.
+	// The target number of blocks that the transaction should be confirmed in.
 	ConfTarget uint32 `protobuf:"varint,2,opt,name=conf_target,json=confTarget,proto3,oneof"`
 }
 
 type OutputWithFee_FeeRateSatPerKw struct {
-	//
-	//The fee rate, in satoshis per kw, to use for the withdrawal transaction.
+	// The fee rate, in satoshis per kw, to use for the withdrawal transaction.
 	FeeRateSatPerKw uint64 `protobuf:"varint,3,opt,name=fee_rate_sat_per_kw,json=feeRateSatPerKw,proto3,oneof"`
 }
 
@@ -903,6 +881,7 @@ type CloseAccountRequest struct {
 	// The trader key associated with the account that will be closed.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
 	// Types that are assignable to FundsDestination:
+	//
 	//	*CloseAccountRequest_OutputWithFee
 	//	*CloseAccountRequest_Outputs
 	FundsDestination isCloseAccountRequest_FundsDestination `protobuf_oneof:"funds_destination"`
@@ -973,20 +952,18 @@ type isCloseAccountRequest_FundsDestination interface {
 }
 
 type CloseAccountRequest_OutputWithFee struct {
-	//
-	//A single output/address to which the remaining funds of the account will
-	//be sent to at the specified fee. If an address is not specified, then
-	//the funds are sent to an address the backing lnd node controls.
+	// A single output/address to which the remaining funds of the account will
+	// be sent to at the specified fee. If an address is not specified, then
+	// the funds are sent to an address the backing lnd node controls.
 	OutputWithFee *OutputWithFee `protobuf:"bytes,2,opt,name=output_with_fee,json=outputWithFee,proto3,oneof"`
 }
 
 type CloseAccountRequest_Outputs struct {
-	//
-	//The outputs to which the remaining funds of the account will be sent to.
-	//This should only be used when wanting to create two or more outputs,
-	//otherwise OutputWithFee should be used instead. The fee of the account's
-	//closing transaction is implicitly defined by the combined value of all
-	//outputs.
+	// The outputs to which the remaining funds of the account will be sent to.
+	// This should only be used when wanting to create two or more outputs,
+	// otherwise OutputWithFee should be used instead. The fee of the account's
+	// closing transaction is implicitly defined by the combined value of all
+	// outputs.
 	Outputs *OutputsWithImplicitFee `protobuf:"bytes,3,opt,name=outputs,proto3,oneof"`
 }
 
@@ -1047,23 +1024,21 @@ type WithdrawAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The trader key associated with the account that funds will be withdrawed
-	//from.
+	// The trader key associated with the account that funds will be withdrawed
+	// from.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
 	// The outputs we'll withdraw funds from the account into.
 	Outputs []*Output `protobuf:"bytes,2,rep,name=outputs,proto3" json:"outputs,omitempty"`
-	//
-	//The fee rate, in satoshis per kw, to use for the withdrawal transaction.
+	// The fee rate, in satoshis per kw, to use for the withdrawal transaction.
 	FeeRateSatPerKw uint64 `protobuf:"varint,3,opt,name=fee_rate_sat_per_kw,json=feeRateSatPerKw,proto3" json:"fee_rate_sat_per_kw,omitempty"`
 	// Types that are assignable to AccountExpiry:
+	//
 	//	*WithdrawAccountRequest_AbsoluteExpiry
 	//	*WithdrawAccountRequest_RelativeExpiry
 	AccountExpiry isWithdrawAccountRequest_AccountExpiry `protobuf_oneof:"account_expiry"`
-	//
-	//The new version of the account. If this is set and is a valid version
-	//greater than the account's current version, then the account is upgraded to
-	//that version during the withdrawal.
+	// The new version of the account. If this is set and is a valid version
+	// greater than the account's current version, then the account is upgraded to
+	// that version during the withdrawal.
 	NewVersion AccountVersion `protobuf:"varint,6,opt,name=new_version,json=newVersion,proto3,enum=poolrpc.AccountVersion" json:"new_version,omitempty"`
 }
 
@@ -1228,23 +1203,21 @@ type DepositAccountRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The trader key associated with the account that funds will be deposited
-	//into.
+	// The trader key associated with the account that funds will be deposited
+	// into.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
 	// The amount in satoshis to deposit into the account.
 	AmountSat uint64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
-	//
-	//The fee rate, in satoshis per kw, to use for the deposit transaction.
+	// The fee rate, in satoshis per kw, to use for the deposit transaction.
 	FeeRateSatPerKw uint64 `protobuf:"varint,3,opt,name=fee_rate_sat_per_kw,json=feeRateSatPerKw,proto3" json:"fee_rate_sat_per_kw,omitempty"`
 	// Types that are assignable to AccountExpiry:
+	//
 	//	*DepositAccountRequest_AbsoluteExpiry
 	//	*DepositAccountRequest_RelativeExpiry
 	AccountExpiry isDepositAccountRequest_AccountExpiry `protobuf_oneof:"account_expiry"`
-	//
-	//The new version of the account. If this is set and is a valid version
-	//greater than the account's current version, then the account is upgraded to
-	//that version during the deposit.
+	// The new version of the account. If this is set and is a valid version
+	// greater than the account's current version, then the account is upgraded to
+	// that version during the deposit.
 	NewVersion AccountVersion `protobuf:"varint,6,opt,name=new_version,json=newVersion,proto3,enum=poolrpc.AccountVersion" json:"new_version,omitempty"`
 }
 
@@ -1412,15 +1385,15 @@ type RenewAccountRequest struct {
 	// The key associated with the account to renew.
 	AccountKey []byte `protobuf:"bytes,1,opt,name=account_key,json=accountKey,proto3" json:"account_key,omitempty"`
 	// Types that are assignable to AccountExpiry:
+	//
 	//	*RenewAccountRequest_AbsoluteExpiry
 	//	*RenewAccountRequest_RelativeExpiry
 	AccountExpiry isRenewAccountRequest_AccountExpiry `protobuf_oneof:"account_expiry"`
 	// The fee rate, in satoshis per kw, to use for the renewal transaction.
 	FeeRateSatPerKw uint64 `protobuf:"varint,4,opt,name=fee_rate_sat_per_kw,json=feeRateSatPerKw,proto3" json:"fee_rate_sat_per_kw,omitempty"`
-	//
-	//The new version of the account. If this is set and is a valid version
-	//greater than the account's current version, then the account is upgraded to
-	//that version during the renewal.
+	// The new version of the account. If this is set and is a valid version
+	// greater than the account's current version, then the account is upgraded to
+	// that version during the renewal.
 	NewVersion AccountVersion `protobuf:"varint,5,opt,name=new_version,json=newVersion,proto3,enum=poolrpc.AccountVersion" json:"new_version,omitempty"`
 }
 
@@ -1578,12 +1551,10 @@ type BumpAccountFeeRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The trader key associated with the account that will have its fee bumped.
+	// The trader key associated with the account that will have its fee bumped.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
-	//
-	//The new fee rate, in satoshis per kw, to use for the child of the account
-	//transaction.
+	// The new fee rate, in satoshis per kw, to use for the child of the account
+	// transaction.
 	FeeRateSatPerKw uint64 `protobuf:"varint,2,opt,name=fee_rate_sat_per_kw,json=feeRateSatPerKw,proto3" json:"fee_rate_sat_per_kw,omitempty"`
 }
 
@@ -1676,19 +1647,16 @@ type Account struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The identifying component of an account. This is the key used for the trader
-	//in the 2-of-2 multi-sig construction of an account with an auctioneer.
+	// The identifying component of an account. This is the key used for the trader
+	// in the 2-of-2 multi-sig construction of an account with an auctioneer.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
-	//
-	//The current outpoint associated with the account. This will change every
-	//time the account has been updated.
+	// The current outpoint associated with the account. This will change every
+	// time the account has been updated.
 	Outpoint *auctioneerrpc.OutPoint `protobuf:"bytes,2,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
 	// The current total amount of satoshis in the account.
 	Value uint64 `protobuf:"varint,3,opt,name=value,proto3" json:"value,omitempty"`
-	//
-	//The amount of satoshis in the account that is available, meaning not
-	//allocated to any oustanding orders.
+	// The amount of satoshis in the account that is available, meaning not
+	// allocated to any oustanding orders.
 	AvailableBalance uint64 `protobuf:"varint,4,opt,name=available_balance,json=availableBalance,proto3" json:"available_balance,omitempty"`
 	// The height at which the account will expire.
 	ExpirationHeight uint32 `protobuf:"varint,5,opt,name=expiration_height,json=expirationHeight,proto3" json:"expiration_height,omitempty"`
@@ -1794,15 +1762,15 @@ type SubmitOrderRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Details:
+	//
 	//	*SubmitOrderRequest_Ask
 	//	*SubmitOrderRequest_Bid
 	Details isSubmitOrderRequest_Details `protobuf_oneof:"details"`
-	//
-	//An optional identification string that will be appended to the user agent
-	//string sent to the server to give information about the usage of pool. This
-	//initiator part is meant for user interfaces to add their name to give the
-	//full picture of the binary used (poold, LiT) and the method used for
-	//submitting the order (pool CLI, LiT UI, other 3rd party UI).
+	// An optional identification string that will be appended to the user agent
+	// string sent to the server to give information about the usage of pool. This
+	// initiator part is meant for user interfaces to add their name to give the
+	// full picture of the binary used (poold, LiT) and the method used for
+	// submitting the order (pool CLI, LiT UI, other 3rd party UI).
 	Initiator string `protobuf:"bytes,3,opt,name=initiator,proto3" json:"initiator,omitempty"`
 }
 
@@ -1888,12 +1856,12 @@ type SubmitOrderResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Details:
+	//
 	//	*SubmitOrderResponse_InvalidOrder
 	//	*SubmitOrderResponse_AcceptedOrderNonce
 	Details isSubmitOrderResponse_Details `protobuf_oneof:"details"`
-	//
-	//In case a bid order was submitted for a sidecar ticket, that ticket is
-	//updated with the new state and bid order nonce.
+	// In case a bid order was submitted for a sidecar ticket, that ticket is
+	// updated with the new state and bid order nonce.
 	UpdatedSidecarTicket string `protobuf:"bytes,3,opt,name=updated_sidecar_ticket,json=updatedSidecarTicket,proto3" json:"updated_sidecar_ticket,omitempty"`
 }
 
@@ -1962,14 +1930,12 @@ type isSubmitOrderResponse_Details interface {
 }
 
 type SubmitOrderResponse_InvalidOrder struct {
-	//
-	//Order failed with the given reason.
+	// Order failed with the given reason.
 	InvalidOrder *auctioneerrpc.InvalidOrder `protobuf:"bytes,1,opt,name=invalid_order,json=invalidOrder,proto3,oneof"`
 }
 
 type SubmitOrderResponse_AcceptedOrderNonce struct {
-	//
-	//The order nonce of the accepted order.
+	// The order nonce of the accepted order.
 	AcceptedOrderNonce []byte `protobuf:"bytes,2,opt,name=accepted_order_nonce,json=acceptedOrderNonce,proto3,oneof"`
 }
 
@@ -1982,12 +1948,10 @@ type ListOrdersRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//Can be set to true to list the orders including all events, which can be
-	//very verbose.
+	// Can be set to true to list the orders including all events, which can be
+	// very verbose.
 	Verbose bool `protobuf:"varint,1,opt,name=verbose,proto3" json:"verbose,omitempty"`
-	//
-	//Only list orders that are still active.
+	// Only list orders that are still active.
 	ActiveOnly bool `protobuf:"varint,2,opt,name=active_only,json=activeOnly,proto3" json:"active_only,omitempty"`
 }
 
@@ -2182,41 +2146,32 @@ type Order struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The trader's account key of the account that is used for the order.
+	// The trader's account key of the account that is used for the order.
 	TraderKey []byte `protobuf:"bytes,1,opt,name=trader_key,json=traderKey,proto3" json:"trader_key,omitempty"`
-	//
-	//Fixed order rate in parts per billion.
+	// Fixed order rate in parts per billion.
 	RateFixed uint32 `protobuf:"varint,2,opt,name=rate_fixed,json=rateFixed,proto3" json:"rate_fixed,omitempty"`
-	//
-	//Order amount in satoshis.
+	// Order amount in satoshis.
 	Amt uint64 `protobuf:"varint,3,opt,name=amt,proto3" json:"amt,omitempty"`
-	//
-	//Maximum fee rate the trader is willing to pay for the batch transaction,
-	//expressed in satoshis per 1000 weight units (sat/KW).
+	// Maximum fee rate the trader is willing to pay for the batch transaction,
+	// expressed in satoshis per 1000 weight units (sat/KW).
 	MaxBatchFeeRateSatPerKw uint64 `protobuf:"varint,4,opt,name=max_batch_fee_rate_sat_per_kw,json=maxBatchFeeRateSatPerKw,proto3" json:"max_batch_fee_rate_sat_per_kw,omitempty"`
-	//
-	//Order nonce, acts as unique order identifier.
+	// Order nonce, acts as unique order identifier.
 	OrderNonce []byte `protobuf:"bytes,5,opt,name=order_nonce,json=orderNonce,proto3" json:"order_nonce,omitempty"`
-	//
-	//The state the order currently is in.
+	// The state the order currently is in.
 	State auctioneerrpc.OrderState `protobuf:"varint,6,opt,name=state,proto3,enum=poolrpc.OrderState" json:"state,omitempty"`
-	//
-	//The number of order units the amount corresponds to.
+	// The number of order units the amount corresponds to.
 	Units uint32 `protobuf:"varint,7,opt,name=units,proto3" json:"units,omitempty"`
-	//
-	//The number of currently unfilled units of this order. This will be equal to
-	//the total amount of units until the order has reached the state PARTIAL_FILL
-	//or EXECUTED.
+	// The number of currently unfilled units of this order. This will be equal to
+	// the total amount of units until the order has reached the state PARTIAL_FILL
+	// or EXECUTED.
 	UnitsUnfulfilled uint32 `protobuf:"varint,8,opt,name=units_unfulfilled,json=unitsUnfulfilled,proto3" json:"units_unfulfilled,omitempty"`
 	// The value reserved from the account by this order to ensure the account
 	// can pay execution and chain fees in case it gets matched.
 	ReservedValueSat uint64 `protobuf:"varint,9,opt,name=reserved_value_sat,json=reservedValueSat,proto3" json:"reserved_value_sat,omitempty"`
 	// The unix timestamp in nanoseconds the order was first created/submitted.
 	CreationTimestampNs uint64 `protobuf:"varint,10,opt,name=creation_timestamp_ns,json=creationTimestampNs,proto3" json:"creation_timestamp_ns,omitempty"`
-	//
-	//A list of events that were emitted for this order. This field is only set
-	//when the verbose flag is set to true in the request.
+	// A list of events that were emitted for this order. This field is only set
+	// when the verbose flag is set to true in the request.
 	Events []*OrderEvent `protobuf:"bytes,11,rep,name=events,proto3" json:"events,omitempty"`
 	// The minimum number of order units that must be matched per order pair.
 	MinUnitsMatch uint32 `protobuf:"varint,12,opt,name=min_units_match,json=minUnitsMatch,proto3" json:"min_units_match,omitempty"`
@@ -2391,40 +2346,32 @@ type Bid struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The common fields shared between both ask and bid order types.
+	// The common fields shared between both ask and bid order types.
 	Details *Order `protobuf:"bytes,1,opt,name=details,proto3" json:"details,omitempty"`
-	//
-	//Required number of blocks that a channel opened as a result of this bid
-	//should be kept open.
+	// Required number of blocks that a channel opened as a result of this bid
+	// should be kept open.
 	LeaseDurationBlocks uint32 `protobuf:"varint,2,opt,name=lease_duration_blocks,json=leaseDurationBlocks,proto3" json:"lease_duration_blocks,omitempty"`
-	//
-	//The version of the order format that is used. Will be increased once new
-	//features are added.
+	// The version of the order format that is used. Will be increased once new
+	// features are added.
 	Version uint32 `protobuf:"varint,3,opt,name=version,proto3" json:"version,omitempty"`
-	//
-	//The minimum node tier this order should be matched with. Only asks backed by
-	//a node this tier or higher will be eligible for matching with this bid.
+	// The minimum node tier this order should be matched with. Only asks backed by
+	// a node this tier or higher will be eligible for matching with this bid.
 	MinNodeTier auctioneerrpc.NodeTier `protobuf:"varint,4,opt,name=min_node_tier,json=minNodeTier,proto3,enum=poolrpc.NodeTier" json:"min_node_tier,omitempty"`
-	//
-	//Give the incoming channel that results from this bid being matched an
-	//initial outbound balance by adding additional funds from the taker's account
-	//into the channel. As a simplification for the execution protocol and the
-	//channel reserve calculations the min_chan_amt must be set to the full order
-	//amount. For the inbound liquidity market the self_chan_balance can be at
-	//most the same as the order amount.
+	// Give the incoming channel that results from this bid being matched an
+	// initial outbound balance by adding additional funds from the taker's account
+	// into the channel. As a simplification for the execution protocol and the
+	// channel reserve calculations the min_chan_amt must be set to the full order
+	// amount. For the inbound liquidity market the self_chan_balance can be at
+	// most the same as the order amount.
 	SelfChanBalance uint64 `protobuf:"varint,5,opt,name=self_chan_balance,json=selfChanBalance,proto3" json:"self_chan_balance,omitempty"`
-	//
-	//If this bid order is meant to lease a channel for another node (which is
-	//dubbed a "sidecar channel") then this ticket contains all information
-	//required for setting up that sidecar channel. The ticket is expected to be
-	//the base58 encoded ticket, including the prefix and the checksum.
+	// If this bid order is meant to lease a channel for another node (which is
+	// dubbed a "sidecar channel") then this ticket contains all information
+	// required for setting up that sidecar channel. The ticket is expected to be
+	// the base58 encoded ticket, including the prefix and the checksum.
 	SidecarTicket string `protobuf:"bytes,6,opt,name=sidecar_ticket,json=sidecarTicket,proto3" json:"sidecar_ticket,omitempty"`
-	//
-	//Signals if this bid is interested in an announced or unannounced channel.
+	// Signals if this bid is interested in an announced or unannounced channel.
 	UnannouncedChannel bool `protobuf:"varint,7,opt,name=unannounced_channel,json=unannouncedChannel,proto3" json:"unannounced_channel,omitempty"`
-	//
-	//Signals if this bid is interested in a zero conf channel or not.
+	// Signals if this bid is interested in a zero conf channel or not.
 	ZeroConfChannel bool `protobuf:"varint,8,opt,name=zero_conf_channel,json=zeroConfChannel,proto3" json:"zero_conf_channel,omitempty"`
 }
 
@@ -2521,23 +2468,18 @@ type Ask struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The common fields shared between both ask and bid order types.
+	// The common fields shared between both ask and bid order types.
 	Details *Order `protobuf:"bytes,1,opt,name=details,proto3" json:"details,omitempty"`
-	//
-	//The number of blocks the liquidity provider is willing to provide the
-	//channel funds for.
+	// The number of blocks the liquidity provider is willing to provide the
+	// channel funds for.
 	LeaseDurationBlocks uint32 `protobuf:"varint,2,opt,name=lease_duration_blocks,json=leaseDurationBlocks,proto3" json:"lease_duration_blocks,omitempty"`
-	//
-	//The version of the order format that is used. Will be increased once new
-	//features are added.
+	// The version of the order format that is used. Will be increased once new
+	// features are added.
 	Version uint32 `protobuf:"varint,3,opt,name=version,proto3" json:"version,omitempty"`
-	//
-	//The constraints for selling the liquidity based on channel discoverability.
+	// The constraints for selling the liquidity based on channel discoverability.
 	AnnouncementConstraints auctioneerrpc.ChannelAnnouncementConstraints `protobuf:"varint,4,opt,name=announcement_constraints,json=announcementConstraints,proto3,enum=poolrpc.ChannelAnnouncementConstraints" json:"announcement_constraints,omitempty"`
-	//
-	//The constraints for selling the liquidity based on the number of
-	//blocks before considering the channel confirmed.
+	// The constraints for selling the liquidity based on the number of
+	// blocks before considering the channel confirmed.
 	ConfirmationConstraints auctioneerrpc.ChannelConfirmationConstraints `protobuf:"varint,5,opt,name=confirmation_constraints,json=confirmationConstraints,proto3,enum=poolrpc.ChannelConfirmationConstraints" json:"confirmation_constraints,omitempty"`
 }
 
@@ -2613,19 +2555,15 @@ type QuoteOrderRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//Order amount in satoshis.
+	// Order amount in satoshis.
 	Amt uint64 `protobuf:"varint,1,opt,name=amt,proto3" json:"amt,omitempty"`
-	//
-	//Fixed order rate in parts per billion.
+	// Fixed order rate in parts per billion.
 	RateFixed uint32 `protobuf:"varint,2,opt,name=rate_fixed,json=rateFixed,proto3" json:"rate_fixed,omitempty"`
-	//
-	//Required number of blocks that a channel opened as a result of this bid
-	//should be kept open.
+	// Required number of blocks that a channel opened as a result of this bid
+	// should be kept open.
 	LeaseDurationBlocks uint32 `protobuf:"varint,3,opt,name=lease_duration_blocks,json=leaseDurationBlocks,proto3" json:"lease_duration_blocks,omitempty"`
-	//
-	//Maximum fee rate the trader is willing to pay for the batch transaction,
-	//expressed in satoshis per 1000 weight units (sat/KW).
+	// Maximum fee rate the trader is willing to pay for the batch transaction,
+	// expressed in satoshis per 1000 weight units (sat/KW).
 	MaxBatchFeeRateSatPerKw uint64 `protobuf:"varint,4,opt,name=max_batch_fee_rate_sat_per_kw,json=maxBatchFeeRateSatPerKw,proto3" json:"max_batch_fee_rate_sat_per_kw,omitempty"`
 	// The minimum number of order units that must be matched per order pair.
 	MinUnitsMatch uint32 `protobuf:"varint,5,opt,name=min_units_match,json=minUnitsMatch,proto3" json:"min_units_match,omitempty"`
@@ -2703,27 +2641,22 @@ type QuoteOrderResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The total order premium in satoshis for filling the entire order. This
-	//represents the interest amount paid to the maker by the taker excluding any
-	//execution or chain fees.
+	// The total order premium in satoshis for filling the entire order. This
+	// represents the interest amount paid to the maker by the taker excluding any
+	// execution or chain fees.
 	TotalPremiumSat uint64 `protobuf:"varint,1,opt,name=total_premium_sat,json=totalPremiumSat,proto3" json:"total_premium_sat,omitempty"`
-	//
-	//The fixed order rate expressed as a fraction instead of parts per billion.
+	// The fixed order rate expressed as a fraction instead of parts per billion.
 	RatePerBlock float64 `protobuf:"fixed64,2,opt,name=rate_per_block,json=ratePerBlock,proto3" json:"rate_per_block,omitempty"`
-	//
-	//The fixed order rate expressed as a percentage instead of parts per billion.
+	// The fixed order rate expressed as a percentage instead of parts per billion.
 	RatePercent float64 `protobuf:"fixed64,3,opt,name=rate_percent,json=ratePercent,proto3" json:"rate_percent,omitempty"`
-	//
-	//The total execution fee in satoshis that needs to be paid to the auctioneer
-	//for executing the entire order.
+	// The total execution fee in satoshis that needs to be paid to the auctioneer
+	// for executing the entire order.
 	TotalExecutionFeeSat uint64 `protobuf:"varint,4,opt,name=total_execution_fee_sat,json=totalExecutionFeeSat,proto3" json:"total_execution_fee_sat,omitempty"`
-	//
-	//The worst case chain fees that need to be paid if fee rates spike up to the
-	//max_batch_fee_rate_sat_per_kw value specified in the request. This value is
-	//highly dependent on the min_units_match parameter as well since the
-	//calculation assumes chain fees for the chain footprint of opening
-	//amt/min_units_match channels (hence worst case calculation).
+	// The worst case chain fees that need to be paid if fee rates spike up to the
+	// max_batch_fee_rate_sat_per_kw value specified in the request. This value is
+	// highly dependent on the min_units_match parameter as well since the
+	// calculation assumes chain fees for the chain footprint of opening
+	// amt/min_units_match channels (hence worst case calculation).
 	WorstCaseChainFeeSat uint64 `protobuf:"varint,5,opt,name=worst_case_chain_fee_sat,json=worstCaseChainFeeSat,proto3" json:"worst_case_chain_fee_sat,omitempty"`
 }
 
@@ -2799,13 +2732,13 @@ type OrderEvent struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The unix timestamp in nanoseconds the event was emitted at. This is the
-	//primary key of the event and is unique across the database.
+	// The unix timestamp in nanoseconds the event was emitted at. This is the
+	// primary key of the event and is unique across the database.
 	TimestampNs int64 `protobuf:"varint,1,opt,name=timestamp_ns,json=timestampNs,proto3" json:"timestamp_ns,omitempty"`
 	// The human readable representation of the event.
 	EventStr string `protobuf:"bytes,2,opt,name=event_str,json=eventStr,proto3" json:"event_str,omitempty"`
 	// Types that are assignable to Event:
+	//
 	//	*OrderEvent_StateChange
 	//	*OrderEvent_Matched
 	Event isOrderEvent_Event `protobuf_oneof:"event"`
@@ -2901,13 +2834,11 @@ type UpdatedEvent struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The state of the order previous to the change. This is what the state
-	//changed from.
+	// The state of the order previous to the change. This is what the state
+	// changed from.
 	PreviousState auctioneerrpc.OrderState `protobuf:"varint,1,opt,name=previous_state,json=previousState,proto3,enum=poolrpc.OrderState" json:"previous_state,omitempty"`
-	//
-	//The new state of the order after the change. This is what the state changed
-	//to.
+	// The new state of the order after the change. This is what the state changed
+	// to.
 	NewState auctioneerrpc.OrderState `protobuf:"varint,2,opt,name=new_state,json=newState,proto3,enum=poolrpc.OrderState" json:"new_state,omitempty"`
 	// The units that were filled at the time of the event.
 	UnitsFilled uint32 `protobuf:"varint,3,opt,name=units_filled,json=unitsFilled,proto3" json:"units_filled,omitempty"`
@@ -2977,9 +2908,8 @@ type MatchEvent struct {
 	UnitsFilled uint32 `protobuf:"varint,2,opt,name=units_filled,json=unitsFilled,proto3" json:"units_filled,omitempty"`
 	// The nonce of the order we were matched to.
 	MatchedOrder []byte `protobuf:"bytes,3,opt,name=matched_order,json=matchedOrder,proto3" json:"matched_order,omitempty"`
-	//
-	//The reason why the trader daemon rejected the order. Is only set if
-	//match_state is set to REJECTED.
+	// The reason why the trader daemon rejected the order. Is only set if
+	// match_state is set to REJECTED.
 	RejectReason MatchRejectReason `protobuf:"varint,4,opt,name=reject_reason,json=rejectReason,proto3,enum=poolrpc.MatchRejectReason" json:"reject_reason,omitempty"`
 }
 
@@ -3048,23 +2978,19 @@ type RecoverAccountsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//Recover the latest account states without interacting with the
-	//Lightning Labs server.
+	// Recover the latest account states without interacting with the
+	// Lightning Labs server.
 	FullClient bool `protobuf:"varint,1,opt,name=full_client,json=fullClient,proto3" json:"full_client,omitempty"`
-	//
-	//Number of accounts that we are trying to recover. Used during the
-	//full_client recovery process.
+	// Number of accounts that we are trying to recover. Used during the
+	// full_client recovery process.
 	AccountTarget uint32 `protobuf:"varint,2,opt,name=account_target,json=accountTarget,proto3" json:"account_target,omitempty"`
-	//
-	//Auctioneer's public key. Used during the full_client recovery process.
-	//This field should be left empty for testnet/mainnet, its value is already
-	//hardcoded in our codebase.
+	// Auctioneer's public key. Used during the full_client recovery process.
+	// This field should be left empty for testnet/mainnet, its value is already
+	// hardcoded in our codebase.
 	AuctioneerKey string `protobuf:"bytes,3,opt,name=auctioneer_key,json=auctioneerKey,proto3" json:"auctioneer_key,omitempty"`
-	//
-	//Initial block height. We won't try to look for any account with an expiry
-	//height smaller than this value. Used during the full_client recovery
-	//process.
+	// Initial block height. We won't try to look for any account with an expiry
+	// height smaller than this value. Used during the full_client recovery
+	// process.
 	HeightHint uint32 `protobuf:"varint,4,opt,name=height_hint,json=heightHint,proto3" json:"height_hint,omitempty"`
 	// bitcoind/btcd instance address. Used during the full_client recovery
 	// process.
@@ -3292,6 +3218,7 @@ type AccountModificationFee struct {
 	// Action transaction fee.
 	//
 	// Types that are assignable to Fee:
+	//
 	//	*AccountModificationFee_FeeNull
 	//	*AccountModificationFee_FeeValue
 	Fee isAccountModificationFee_Fee `protobuf_oneof:"fee"`
@@ -3542,8 +3469,7 @@ type AuctionFeeResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The execution fee charged per matched order.
+	// The execution fee charged per matched order.
 	ExecutionFee *auctioneerrpc.ExecutionFee `protobuf:"bytes,1,opt,name=execution_fee,json=executionFee,proto3" json:"execution_fee,omitempty"`
 }
 
@@ -3599,30 +3525,24 @@ type Lease struct {
 	ChannelDurationBlocks uint32 `protobuf:"varint,3,opt,name=channel_duration_blocks,json=channelDurationBlocks,proto3" json:"channel_duration_blocks,omitempty"`
 	// The absolute height that this channel lease expires.
 	ChannelLeaseExpiry uint32 `protobuf:"varint,4,opt,name=channel_lease_expiry,json=channelLeaseExpiry,proto3" json:"channel_lease_expiry,omitempty"`
-	//
-	//The premium, in satoshis, either paid or received for the offered liquidity.
+	// The premium, in satoshis, either paid or received for the offered liquidity.
 	PremiumSat uint64 `protobuf:"varint,5,opt,name=premium_sat,json=premiumSat,proto3" json:"premium_sat,omitempty"`
-	//
-	//The execution fee, in satoshis, charged by the auctioneer for the channel
-	//created.
+	// The execution fee, in satoshis, charged by the auctioneer for the channel
+	// created.
 	ExecutionFeeSat uint64 `protobuf:"varint,6,opt,name=execution_fee_sat,json=executionFeeSat,proto3" json:"execution_fee_sat,omitempty"`
-	//
-	//The fee, in satoshis, charged by the auctioneer for the batch execution
-	//transaction that created this lease.
+	// The fee, in satoshis, charged by the auctioneer for the batch execution
+	// transaction that created this lease.
 	ChainFeeSat uint64 `protobuf:"varint,7,opt,name=chain_fee_sat,json=chainFeeSat,proto3" json:"chain_fee_sat,omitempty"`
-	//
-	//The actual fixed rate expressed in parts per billionth this lease was
-	//bought/sold at.
+	// The actual fixed rate expressed in parts per billionth this lease was
+	// bought/sold at.
 	ClearingRatePrice uint64 `protobuf:"varint,8,opt,name=clearing_rate_price,json=clearingRatePrice,proto3" json:"clearing_rate_price,omitempty"`
-	//
-	//The actual fixed rate of the bid/ask, this should always be 'better' than
-	//the clearing_rate_price.
+	// The actual fixed rate of the bid/ask, this should always be 'better' than
+	// the clearing_rate_price.
 	OrderFixedRate uint64 `protobuf:"varint,9,opt,name=order_fixed_rate,json=orderFixedRate,proto3" json:"order_fixed_rate,omitempty"`
 	// The order executed that resulted in the channel created.
 	OrderNonce []byte `protobuf:"bytes,10,opt,name=order_nonce,json=orderNonce,proto3" json:"order_nonce,omitempty"`
-	//
-	//The unique identifier for the order that was matched with that resulted
-	//in the channel created.
+	// The unique identifier for the order that was matched with that resulted
+	// in the channel created.
 	MatchedOrderNonce []byte `protobuf:"bytes,16,opt,name=matched_order_nonce,json=matchedOrderNonce,proto3" json:"matched_order_nonce,omitempty"`
 	// Whether this channel was purchased from another trader or not.
 	Purchased bool `protobuf:"varint,11,opt,name=purchased,proto3" json:"purchased,omitempty"`
@@ -3785,13 +3705,11 @@ type LeasesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//An optional list of batches to retrieve the leases of. If empty, leases
-	//throughout all batches are returned.
+	// An optional list of batches to retrieve the leases of. If empty, leases
+	// throughout all batches are returned.
 	BatchIds [][]byte `protobuf:"bytes,1,rep,name=batch_ids,json=batchIds,proto3" json:"batch_ids,omitempty"`
-	//
-	//An optional list of accounts to retrieve the leases of. If empty, leases
-	//for all accounts are returned.
+	// An optional list of accounts to retrieve the leases of. If empty, leases
+	// for all accounts are returned.
 	Accounts [][]byte `protobuf:"bytes,2,rep,name=accounts,proto3" json:"accounts,omitempty"`
 }
 
@@ -3950,8 +3868,8 @@ type TokensResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//*
-	//List of all tokens the daemon knows of, including old/expired tokens.
+	// *
+	// List of all tokens the daemon knows of, including old/expired tokens.
 	Tokens []*LsatToken `protobuf:"bytes,1,rep,name=tokens,proto3" json:"tokens,omitempty"`
 }
 
@@ -3999,32 +3917,32 @@ type LsatToken struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//*
-	//The base macaroon that was baked by the auth server.
+	// *
+	// The base macaroon that was baked by the auth server.
 	BaseMacaroon []byte `protobuf:"bytes,1,opt,name=base_macaroon,json=baseMacaroon,proto3" json:"base_macaroon,omitempty"`
-	//*
-	//The payment hash of the payment that was paid to obtain the token.
+	// *
+	// The payment hash of the payment that was paid to obtain the token.
 	PaymentHash []byte `protobuf:"bytes,2,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
-	//*
-	//The preimage of the payment hash, knowledge of this is proof that the
-	//payment has been paid. If the preimage is set to all zeros, this means the
-	//payment is still pending and the token is not yet fully valid.
+	// *
+	// The preimage of the payment hash, knowledge of this is proof that the
+	// payment has been paid. If the preimage is set to all zeros, this means the
+	// payment is still pending and the token is not yet fully valid.
 	PaymentPreimage []byte `protobuf:"bytes,3,opt,name=payment_preimage,json=paymentPreimage,proto3" json:"payment_preimage,omitempty"`
-	//*
-	//The amount of millisatoshis that was paid to get the token.
+	// *
+	// The amount of millisatoshis that was paid to get the token.
 	AmountPaidMsat int64 `protobuf:"varint,4,opt,name=amount_paid_msat,json=amountPaidMsat,proto3" json:"amount_paid_msat,omitempty"`
-	//*
-	//The amount of millisatoshis paid in routing fee to pay for the token.
+	// *
+	// The amount of millisatoshis paid in routing fee to pay for the token.
 	RoutingFeePaidMsat int64 `protobuf:"varint,5,opt,name=routing_fee_paid_msat,json=routingFeePaidMsat,proto3" json:"routing_fee_paid_msat,omitempty"`
-	//*
-	//The creation time of the token as UNIX timestamp in seconds.
+	// *
+	// The creation time of the token as UNIX timestamp in seconds.
 	TimeCreated int64 `protobuf:"varint,6,opt,name=time_created,json=timeCreated,proto3" json:"time_created,omitempty"`
-	//*
-	//Indicates whether the token is expired or still valid.
+	// *
+	// Indicates whether the token is expired or still valid.
 	Expired bool `protobuf:"varint,7,opt,name=expired,proto3" json:"expired,omitempty"`
-	//*
-	//Identifying attribute of this token in the store. Currently represents the
-	//file name of the token where it's stored on the file system.
+	// *
+	// Identifying attribute of this token in the store. Currently represents the
+	// file name of the token where it's stored on the file system.
 	StorageName string `protobuf:"bytes,8,opt,name=storage_name,json=storageName,proto3" json:"storage_name,omitempty"`
 }
 
@@ -4159,14 +4077,12 @@ type LeaseDurationResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//Deprecated, use lease_duration_buckets.
+	// Deprecated, use lease_duration_buckets.
 	//
 	// Deprecated: Do not use.
 	LeaseDurations map[uint32]bool `protobuf:"bytes,1,rep,name=lease_durations,json=leaseDurations,proto3" json:"lease_durations,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
-	//
-	//The set of lease durations the market is currently accepting and the state
-	//the duration buckets currently are in.
+	// The set of lease durations the market is currently accepting and the state
+	// the duration buckets currently are in.
 	LeaseDurationBuckets map[uint32]auctioneerrpc.DurationBucketState `protobuf:"bytes,2,rep,name=lease_duration_buckets,json=leaseDurationBuckets,proto3" json:"lease_duration_buckets,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3,enum=poolrpc.DurationBucketState"`
 }
 
@@ -4260,21 +4176,17 @@ type NextBatchInfoResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The confirmation target the auctioneer will use for fee estimation of the
-	//next batch.
+	// The confirmation target the auctioneer will use for fee estimation of the
+	// next batch.
 	ConfTarget uint32 `protobuf:"varint,5,opt,name=conf_target,json=confTarget,proto3" json:"conf_target,omitempty"`
-	//
-	//The fee rate, in satoshis per kiloweight, estimated by the auctioneer to use
-	//for the next batch.
+	// The fee rate, in satoshis per kiloweight, estimated by the auctioneer to use
+	// for the next batch.
 	FeeRateSatPerKw uint64 `protobuf:"varint,6,opt,name=fee_rate_sat_per_kw,json=feeRateSatPerKw,proto3" json:"fee_rate_sat_per_kw,omitempty"`
-	//
-	//The absolute unix timestamp in seconds at which the auctioneer will attempt
-	//to clear the next batch.
+	// The absolute unix timestamp in seconds at which the auctioneer will attempt
+	// to clear the next batch.
 	ClearTimestamp uint64 `protobuf:"varint,7,opt,name=clear_timestamp,json=clearTimestamp,proto3" json:"clear_timestamp,omitempty"`
-	//
-	//The value used by the auctioneer to determine if an account expiry height
-	//needs to be extended after participating in a batch and for how long.
+	// The value used by the auctioneer to determine if an account expiry height
+	// needs to be extended after participating in a batch and for how long.
 	AutoRenewExtensionBlocks uint32 `protobuf:"varint,8,opt,name=auto_renew_extension_blocks,json=autoRenewExtensionBlocks,proto3" json:"auto_renew_extension_blocks,omitempty"`
 }
 
@@ -4481,9 +4393,8 @@ type GetInfoResponse struct {
 	Version string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
 	// The total number of accounts in the local database.
 	AccountsTotal uint32 `protobuf:"varint,2,opt,name=accounts_total,json=accountsTotal,proto3" json:"accounts_total,omitempty"`
-	//
-	//The total number of accounts that are in an active, non-archived state,
-	//including expired accounts.
+	// The total number of accounts that are in an active, non-archived state,
+	// including expired accounts.
 	AccountsActive uint32 `protobuf:"varint,3,opt,name=accounts_active,json=accountsActive,proto3" json:"accounts_active,omitempty"`
 	// The total number of accounts that are active but have expired.
 	AccountsActiveExpired uint32 `protobuf:"varint,4,opt,name=accounts_active_expired,json=accountsActiveExpired,proto3" json:"accounts_active_expired,omitempty"`
@@ -4491,9 +4402,8 @@ type GetInfoResponse struct {
 	AccountsArchived uint32 `protobuf:"varint,5,opt,name=accounts_archived,json=accountsArchived,proto3" json:"accounts_archived,omitempty"`
 	// The total number of orders in the local database.
 	OrdersTotal uint32 `protobuf:"varint,6,opt,name=orders_total,json=ordersTotal,proto3" json:"orders_total,omitempty"`
-	//
-	//The total number of active/pending orders that are still waiting for
-	//execution.
+	// The total number of active/pending orders that are still waiting for
+	// execution.
 	OrdersActive uint32 `protobuf:"varint,7,opt,name=orders_active,json=ordersActive,proto3" json:"orders_active,omitempty"`
 	// The total number of orders that have been archived.
 	OrdersArchived uint32 `protobuf:"varint,8,opt,name=orders_archived,json=ordersArchived,proto3" json:"orders_archived,omitempty"`
@@ -4505,21 +4415,18 @@ type GetInfoResponse struct {
 	NodeRating *auctioneerrpc.NodeRating `protobuf:"bytes,11,opt,name=node_rating,json=nodeRating,proto3" json:"node_rating,omitempty"`
 	// The number of available LSAT tokens.
 	LsatTokens uint32 `protobuf:"varint,12,opt,name=lsat_tokens,json=lsatTokens,proto3" json:"lsat_tokens,omitempty"`
-	//
-	//Indicates whether there is an active subscription connection to the
-	//auctioneer. This will never be true if there is no active account. If there
-	//are active accounts, this value represents the network connection status to
-	//the auctioneer server.
+	// Indicates whether there is an active subscription connection to the
+	// auctioneer. This will never be true if there is no active account. If there
+	// are active accounts, this value represents the network connection status to
+	// the auctioneer server.
 	SubscribedToAuctioneer bool `protobuf:"varint,13,opt,name=subscribed_to_auctioneer,json=subscribedToAuctioneer,proto3" json:"subscribed_to_auctioneer,omitempty"`
-	//
-	//Indicates whether the global `--newnodesonly` command line flag or
-	//`newnodesonly=true` configuration parameter was set on the Pool trader
-	//daemon.
+	// Indicates whether the global `--newnodesonly` command line flag or
+	// `newnodesonly=true` configuration parameter was set on the Pool trader
+	// daemon.
 	NewNodesOnly bool `protobuf:"varint,14,opt,name=new_nodes_only,json=newNodesOnly,proto3" json:"new_nodes_only,omitempty"`
-	//
-	//A map of all markets identified by their lease duration and the current
-	//set of statistics such as number of open orders and total units of open
-	//interest.
+	// A map of all markets identified by their lease duration and the current
+	// set of statistics such as number of open orders and total units of open
+	// interest.
 	MarketInfo map[uint32]*auctioneerrpc.MarketInfo `protobuf:"bytes,15,rep,name=market_info,json=marketInfo,proto3" json:"market_info,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -4741,15 +4648,13 @@ type OfferSidecarRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//If false, then only the trader_key, unit, self_chan_balance, and
-	//lease_duration_blocks need to be set in the bid below. Otherwise, the
-	//fields as they're set when submitting a bid need to be filled in.
+	// If false, then only the trader_key, unit, self_chan_balance, and
+	// lease_duration_blocks need to be set in the bid below. Otherwise, the
+	// fields as they're set when submitting a bid need to be filled in.
 	AutoNegotiate bool `protobuf:"varint,1,opt,name=auto_negotiate,json=autoNegotiate,proto3" json:"auto_negotiate,omitempty"`
-	//
-	//The bid template that will be used to populate the initial sidecar ticket
-	//as well as auto negotiate the remainig steps of the sidecar channel if
-	//needed.
+	// The bid template that will be used to populate the initial sidecar ticket
+	// as well as auto negotiate the remainig steps of the sidecar channel if
+	// needed.
 	Bid *Bid `protobuf:"bytes,2,opt,name=bid,proto3" json:"bid,omitempty"`
 }
 
@@ -4804,12 +4709,11 @@ type SidecarTicket struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The complete sidecar ticket in its string encoded form which is base58
-	//encoded, has a human readable prefix ('sidecar...') and a checksum built in.
-	//The string encoded version will only be used on the trader side of the API.
-	//All requests to the auctioneer expect the ticket to be in its raw, tlv
-	//encoded byte form.
+	// The complete sidecar ticket in its string encoded form which is base58
+	// encoded, has a human readable prefix ('sidecar...') and a checksum built in.
+	// The string encoded version will only be used on the trader side of the API.
+	// All requests to the auctioneer expect the ticket to be in its raw, tlv
+	// encoded byte form.
 	Ticket string `protobuf:"bytes,1,opt,name=ticket,proto3" json:"ticket,omitempty"`
 }
 
@@ -4877,17 +4781,15 @@ type DecodedSidecarTicket struct {
 	OfferAuto bool `protobuf:"varint,9,opt,name=offer_auto,json=offerAuto,proto3" json:"offer_auto,omitempty"`
 	// The recipient node's public identity key.
 	RecipientNodePubkey []byte `protobuf:"bytes,10,opt,name=recipient_node_pubkey,json=recipientNodePubkey,proto3" json:"recipient_node_pubkey,omitempty"`
-	//
-	//The recipient node's channel multisig public key to be used for the sidecar
-	//channel.
+	// The recipient node's channel multisig public key to be used for the sidecar
+	// channel.
 	RecipientMultisigPubkey []byte `protobuf:"bytes,11,opt,name=recipient_multisig_pubkey,json=recipientMultisigPubkey,proto3" json:"recipient_multisig_pubkey,omitempty"`
 	// The index used when deriving the above multisig pubkey.
 	RecipientMultisigPubkeyIndex uint32 `protobuf:"varint,12,opt,name=recipient_multisig_pubkey_index,json=recipientMultisigPubkeyIndex,proto3" json:"recipient_multisig_pubkey_index,omitempty"`
 	// The nonce of the bid order created for this sidecar ticket.
 	OrderBidNonce []byte `protobuf:"bytes,13,opt,name=order_bid_nonce,json=orderBidNonce,proto3" json:"order_bid_nonce,omitempty"`
-	//
-	//The signature over the order's digest, signed with the private key that
-	//corresponds to the offer_sign_pubkey.
+	// The signature over the order's digest, signed with the private key that
+	// corresponds to the offer_sign_pubkey.
 	OrderSignature []byte `protobuf:"bytes,14,opt,name=order_signature,json=orderSignature,proto3" json:"order_signature,omitempty"`
 	// The pending channel ID of the sidecar channel during the execution phase.
 	ExecutionPendingChannelId []byte `protobuf:"bytes,15,opt,name=execution_pending_channel_id,json=executionPendingChannelId,proto3" json:"execution_pending_channel_id,omitempty"`
@@ -5064,16 +4966,14 @@ type RegisterSidecarRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The sidecar ticket to register and add the node and channel funding
-	//information to. The ticket must be in the state "offered".
+	// The sidecar ticket to register and add the node and channel funding
+	// information to. The ticket must be in the state "offered".
 	Ticket string `protobuf:"bytes,1,opt,name=ticket,proto3" json:"ticket,omitempty"`
-	//
-	//If this value is True, then the daemon will attempt to finish negotiating
-	//the details of the sidecar channel automatically in the background. The
-	//progress of the ticket can be monitored using the SidecarState RPC. In
-	//addition, if this flag is set, then this method will _block_ until the
-	//sidecar negotiation either finishes or breaks down.
+	// If this value is True, then the daemon will attempt to finish negotiating
+	// the details of the sidecar channel automatically in the background. The
+	// progress of the ticket can be monitored using the SidecarState RPC. In
+	// addition, if this flag is set, then this method will _block_ until the
+	// sidecar negotiation either finishes or breaks down.
 	AutoNegotiate bool `protobuf:"varint,2,opt,name=auto_negotiate,json=autoNegotiate,proto3" json:"auto_negotiate,omitempty"`
 }
 
@@ -5128,9 +5028,8 @@ type ExpectSidecarChannelRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The sidecar ticket to expect an incoming channel for. The ticket must be in
-	//the state "ordered".
+	// The sidecar ticket to expect an incoming channel for. The ticket must be in
+	// the state "ordered".
 	Ticket string `protobuf:"bytes,1,opt,name=ticket,proto3" json:"ticket,omitempty"`
 }
 
@@ -5216,18 +5115,17 @@ type ListSidecarsRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//The optional sidecar ID to filter for. If set, the result should either be
-	//a single ticket or no ticket in most cases. But because the ID is just 8
-	//bytes and is randomly generated, there could be collisions, especially since
-	//tickets can also be crafted by a malicious party and given to any node.
-	//That's why the offer's public key is also used as an identifying element
-	//since that cannot easily be forged without also producing a valid signature.
-	//So an attacker cannot overwrite a ticket a node offered by themselves
-	//offering a ticket with the same ID and tricking the victim into registering
-	//that. Long story sort, there could be multiple tickets with the same ID but
-	//different offer public keys, which is why those keys should be checked as
-	//well.
+	// The optional sidecar ID to filter for. If set, the result should either be
+	// a single ticket or no ticket in most cases. But because the ID is just 8
+	// bytes and is randomly generated, there could be collisions, especially since
+	// tickets can also be crafted by a malicious party and given to any node.
+	// That's why the offer's public key is also used as an identifying element
+	// since that cannot easily be forged without also producing a valid signature.
+	// So an attacker cannot overwrite a ticket a node offered by themselves
+	// offering a ticket with the same ID and tricking the victim into registering
+	// that. Long story sort, there could be multiple tickets with the same ID but
+	// different offer public keys, which is why those keys should be checked as
+	// well.
 	SidecarId []byte `protobuf:"bytes,1,opt,name=sidecar_id,json=sidecarId,proto3" json:"sidecar_id,omitempty"`
 }
 

--- a/poolrpc/trader_grpc.pb.go
+++ b/poolrpc/trader_grpc.pb.go
@@ -20,146 +20,144 @@ const _ = grpc.SupportPackageIsVersion7
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type TraderClient interface {
 	// pool: `getinfo`
-	//GetInfo returns general information about the state of the Pool trader
-	//daemon.
+	// GetInfo returns general information about the state of the Pool trader
+	// daemon.
 	GetInfo(ctx context.Context, in *GetInfoRequest, opts ...grpc.CallOption) (*GetInfoResponse, error)
 	// pool: `stop`
-	//Stop gracefully shuts down the Pool trader daemon.
+	// Stop gracefully shuts down the Pool trader daemon.
 	StopDaemon(ctx context.Context, in *StopDaemonRequest, opts ...grpc.CallOption) (*StopDaemonResponse, error)
-	//
-	//QuoteAccount gets a fee quote to fund an account of the given size with the
-	//given confirmation target. If the connected lnd wallet doesn't have enough
-	//balance to fund an account of the requested size, an error is returned.
+	// QuoteAccount gets a fee quote to fund an account of the given size with the
+	// given confirmation target. If the connected lnd wallet doesn't have enough
+	// balance to fund an account of the requested size, an error is returned.
 	QuoteAccount(ctx context.Context, in *QuoteAccountRequest, opts ...grpc.CallOption) (*QuoteAccountResponse, error)
 	// pool: `accounts new`
-	//InitAccount creates a new account with the requested size and expiration,
-	//funding it from the wallet of the connected lnd node.
+	// InitAccount creates a new account with the requested size and expiration,
+	// funding it from the wallet of the connected lnd node.
 	InitAccount(ctx context.Context, in *InitAccountRequest, opts ...grpc.CallOption) (*Account, error)
 	// pool: `accounts list`
-	//ListAccounts returns a list of all accounts known to the trader daemon and
-	//their current state.
+	// ListAccounts returns a list of all accounts known to the trader daemon and
+	// their current state.
 	ListAccounts(ctx context.Context, in *ListAccountsRequest, opts ...grpc.CallOption) (*ListAccountsResponse, error)
 	// pool: `accounts close`
-	//CloseAccount closes an account and returns the funds locked in that account
-	//to the connected lnd node's wallet.
+	// CloseAccount closes an account and returns the funds locked in that account
+	// to the connected lnd node's wallet.
 	CloseAccount(ctx context.Context, in *CloseAccountRequest, opts ...grpc.CallOption) (*CloseAccountResponse, error)
 	// pool: `accounts withdraw`
-	//WithdrawAccount splits off parts of the account balance into the specified
-	//outputs while recreating the account with a reduced balance.
+	// WithdrawAccount splits off parts of the account balance into the specified
+	// outputs while recreating the account with a reduced balance.
 	WithdrawAccount(ctx context.Context, in *WithdrawAccountRequest, opts ...grpc.CallOption) (*WithdrawAccountResponse, error)
 	// pool: `accounts deposit`
-	//DepositAccount adds more funds from the connected lnd node's wallet to an
-	//account.
+	// DepositAccount adds more funds from the connected lnd node's wallet to an
+	// account.
 	DepositAccount(ctx context.Context, in *DepositAccountRequest, opts ...grpc.CallOption) (*DepositAccountResponse, error)
 	// pool: `accounts renew`
-	//RenewAccount renews the expiration of an account.
+	// RenewAccount renews the expiration of an account.
 	RenewAccount(ctx context.Context, in *RenewAccountRequest, opts ...grpc.CallOption) (*RenewAccountResponse, error)
 	// pool: `accounts bumpfee`
-	//BumpAccountFee attempts to bump the fee of an account's transaction through
-	//child-pays-for-parent (CPFP). Since the CPFP is performed through the
-	//backing lnd node, the account transaction must contain an output under its
-	//control for a successful bump. If a CPFP has already been performed for an
-	//account, and this RPC is invoked again, then a replacing transaction (RBF)
-	//of the child will be broadcast.
+	// BumpAccountFee attempts to bump the fee of an account's transaction through
+	// child-pays-for-parent (CPFP). Since the CPFP is performed through the
+	// backing lnd node, the account transaction must contain an output under its
+	// control for a successful bump. If a CPFP has already been performed for an
+	// account, and this RPC is invoked again, then a replacing transaction (RBF)
+	// of the child will be broadcast.
 	BumpAccountFee(ctx context.Context, in *BumpAccountFeeRequest, opts ...grpc.CallOption) (*BumpAccountFeeResponse, error)
 	// pool: `accounts recover`
-	//RecoverAccounts queries the auction server for this trader daemon's accounts
-	//in case we lost our local account database.
+	// RecoverAccounts queries the auction server for this trader daemon's accounts
+	// in case we lost our local account database.
 	RecoverAccounts(ctx context.Context, in *RecoverAccountsRequest, opts ...grpc.CallOption) (*RecoverAccountsResponse, error)
 	// pool: `accounts listfees`
-	//AccountModificationFees returns a map from account key to an ordered list of
-	//account action modification fees.
+	// AccountModificationFees returns a map from account key to an ordered list of
+	// account action modification fees.
 	AccountModificationFees(ctx context.Context, in *AccountModificationFeesRequest, opts ...grpc.CallOption) (*AccountModificationFeesResponse, error)
 	// pool: `orders submit`
-	//SubmitOrder creates a new ask or bid order and submits for the given account
-	//and submits it to the auction server for matching.
+	// SubmitOrder creates a new ask or bid order and submits for the given account
+	// and submits it to the auction server for matching.
 	SubmitOrder(ctx context.Context, in *SubmitOrderRequest, opts ...grpc.CallOption) (*SubmitOrderResponse, error)
 	// pool: `orders list`
-	//ListOrders returns a list of all active and archived orders that are
-	//currently known to the trader daemon.
+	// ListOrders returns a list of all active and archived orders that are
+	// currently known to the trader daemon.
 	ListOrders(ctx context.Context, in *ListOrdersRequest, opts ...grpc.CallOption) (*ListOrdersResponse, error)
 	// pool: `orders cancel`
-	//CancelOrder cancels an active order with the auction server to remove it
-	//from future matching.
+	// CancelOrder cancels an active order with the auction server to remove it
+	// from future matching.
 	CancelOrder(ctx context.Context, in *CancelOrderRequest, opts ...grpc.CallOption) (*CancelOrderResponse, error)
-	//
-	//QuoteOrder calculates the premium, execution fees and max batch fee rate for
-	//an order based on the given order parameters.
+	// QuoteOrder calculates the premium, execution fees and max batch fee rate for
+	// an order based on the given order parameters.
 	QuoteOrder(ctx context.Context, in *QuoteOrderRequest, opts ...grpc.CallOption) (*QuoteOrderResponse, error)
 	// pool: `auction fee`
-	//AuctionFee returns the current auction order execution fee specified by the
-	//auction server.
+	// AuctionFee returns the current auction order execution fee specified by the
+	// auction server.
 	AuctionFee(ctx context.Context, in *AuctionFeeRequest, opts ...grpc.CallOption) (*AuctionFeeResponse, error)
 	// pool: `auction leasedurations`
-	//LeaseDurations returns the current set of valid lease duration in the
-	//market as is, and also information w.r.t if the market is currently active.
+	// LeaseDurations returns the current set of valid lease duration in the
+	// market as is, and also information w.r.t if the market is currently active.
 	LeaseDurations(ctx context.Context, in *LeaseDurationRequest, opts ...grpc.CallOption) (*LeaseDurationResponse, error)
 	// pool: `auction nextbatchinfo`
-	//NextBatchInfo returns information about the next batch the auctioneer will
-	//perform.
+	// NextBatchInfo returns information about the next batch the auctioneer will
+	// perform.
 	NextBatchInfo(ctx context.Context, in *NextBatchInfoRequest, opts ...grpc.CallOption) (*NextBatchInfoResponse, error)
 	// pool: `auction snapshot`
-	//BatchSnapshot returns the snapshot of a past batch identified by its ID.
-	//If no ID is provided, the snapshot of the last finalized batch is returned.
-	//Deprecated, use BatchSnapshots instead.
+	// BatchSnapshot returns the snapshot of a past batch identified by its ID.
+	// If no ID is provided, the snapshot of the last finalized batch is returned.
+	// Deprecated, use BatchSnapshots instead.
 	BatchSnapshot(ctx context.Context, in *auctioneerrpc.BatchSnapshotRequest, opts ...grpc.CallOption) (*auctioneerrpc.BatchSnapshotResponse, error)
 	// pool: `listauth`
-	//GetLsatTokens returns all LSAT tokens the daemon ever paid for.
+	// GetLsatTokens returns all LSAT tokens the daemon ever paid for.
 	GetLsatTokens(ctx context.Context, in *TokensRequest, opts ...grpc.CallOption) (*TokensResponse, error)
 	// pool: `auction leases`
-	//Leases returns the list of channels that were either purchased or sold by
-	//the trader within the auction.
+	// Leases returns the list of channels that were either purchased or sold by
+	// the trader within the auction.
 	Leases(ctx context.Context, in *LeasesRequest, opts ...grpc.CallOption) (*LeasesResponse, error)
 	// pool: `auction ratings`
-	//Returns the Node Tier information for this target Lightning node, and other
-	//related ranking information.
+	// Returns the Node Tier information for this target Lightning node, and other
+	// related ranking information.
 	NodeRatings(ctx context.Context, in *NodeRatingRequest, opts ...grpc.CallOption) (*NodeRatingResponse, error)
 	// pool: `auction snapshot`
-	//BatchSnapshots returns a list of batch snapshots starting at the start batch
-	//ID and going back through the history of batches, returning at most the
-	//number of specified batches. A maximum of 100 snapshots can be queried in
-	//one call. If no start batch ID is provided, the most recent finalized batch
-	//is used as the starting point to go back from.
+	// BatchSnapshots returns a list of batch snapshots starting at the start batch
+	// ID and going back through the history of batches, returning at most the
+	// number of specified batches. A maximum of 100 snapshots can be queried in
+	// one call. If no start batch ID is provided, the most recent finalized batch
+	// is used as the starting point to go back from.
 	BatchSnapshots(ctx context.Context, in *auctioneerrpc.BatchSnapshotsRequest, opts ...grpc.CallOption) (*auctioneerrpc.BatchSnapshotsResponse, error)
 	// pool: `sidecar offer`
-	//OfferSidecar is step 1/4 of the sidecar negotiation between the provider
-	//(the trader submitting the bid order) and the recipient (the trader
-	//receiving the sidecar channel).
-	//This step must be run by the provider. The result is a sidecar ticket with
-	//an offer to lease a sidecar channel for the recipient. The offer will be
-	//signed with the provider's lnd node public key. The ticket returned by this
-	//call will have the state "offered".
+	// OfferSidecar is step 1/4 of the sidecar negotiation between the provider
+	// (the trader submitting the bid order) and the recipient (the trader
+	// receiving the sidecar channel).
+	// This step must be run by the provider. The result is a sidecar ticket with
+	// an offer to lease a sidecar channel for the recipient. The offer will be
+	// signed with the provider's lnd node public key. The ticket returned by this
+	// call will have the state "offered".
 	OfferSidecar(ctx context.Context, in *OfferSidecarRequest, opts ...grpc.CallOption) (*SidecarTicket, error)
 	// pool: `sidecar register`
-	//RegisterSidecarRequest is step 2/4 of the sidecar negotiation between the
-	//provider (the trader submitting the bid order) and the recipient (the trader
-	//receiving the sidecar channel).
-	//This step must be run by the recipient. The result is a sidecar ticket with
-	//the recipient's node information and channel funding multisig pubkey filled
-	//in. The ticket returned by this call will have the state "registered".
+	// RegisterSidecarRequest is step 2/4 of the sidecar negotiation between the
+	// provider (the trader submitting the bid order) and the recipient (the trader
+	// receiving the sidecar channel).
+	// This step must be run by the recipient. The result is a sidecar ticket with
+	// the recipient's node information and channel funding multisig pubkey filled
+	// in. The ticket returned by this call will have the state "registered".
 	RegisterSidecar(ctx context.Context, in *RegisterSidecarRequest, opts ...grpc.CallOption) (*SidecarTicket, error)
 	// pool: `sidecar expectchannel`
-	//ExpectSidecarChannel is step 4/4 of the sidecar negotiation between the
-	//provider (the trader submitting the bid order) and the recipient (the trader
-	//receiving the sidecar channel).
-	//This step must be run by the recipient once the provider has submitted the
-	//bid order for the sidecar channel. From this point onwards the Pool trader
-	//daemon of both the provider as well as the recipient need to be online to
-	//receive and react to match making events from the server.
+	// ExpectSidecarChannel is step 4/4 of the sidecar negotiation between the
+	// provider (the trader submitting the bid order) and the recipient (the trader
+	// receiving the sidecar channel).
+	// This step must be run by the recipient once the provider has submitted the
+	// bid order for the sidecar channel. From this point onwards the Pool trader
+	// daemon of both the provider as well as the recipient need to be online to
+	// receive and react to match making events from the server.
 	ExpectSidecarChannel(ctx context.Context, in *ExpectSidecarChannelRequest, opts ...grpc.CallOption) (*ExpectSidecarChannelResponse, error)
 	// pool: `sidecar printticket`
-	//Decodes the base58 encoded sidecar ticket into its individual data fields
-	//for a more human-readable representation.
+	// Decodes the base58 encoded sidecar ticket into its individual data fields
+	// for a more human-readable representation.
 	DecodeSidecarTicket(ctx context.Context, in *SidecarTicket, opts ...grpc.CallOption) (*DecodedSidecarTicket, error)
 	// pool: `sidecar list`
-	//ListSidecars lists all sidecar tickets currently in the local database. This
-	//includes tickets offered by our node as well as tickets that our node is the
-	//recipient of. Optionally a ticket ID can be provided to filter the tickets.
+	// ListSidecars lists all sidecar tickets currently in the local database. This
+	// includes tickets offered by our node as well as tickets that our node is the
+	// recipient of. Optionally a ticket ID can be provided to filter the tickets.
 	ListSidecars(ctx context.Context, in *ListSidecarsRequest, opts ...grpc.CallOption) (*ListSidecarsResponse, error)
 	// pool: `sidecar cancel`
-	//CancelSidecar cancels the execution of a specific sidecar ticket. Depending
-	//on the state of the sidecar ticket its associated bid order might be
-	//canceled as well (if this ticket was offered by our node).
+	// CancelSidecar cancels the execution of a specific sidecar ticket. Depending
+	// on the state of the sidecar ticket its associated bid order might be
+	// canceled as well (if this ticket was offered by our node).
 	CancelSidecar(ctx context.Context, in *CancelSidecarRequest, opts ...grpc.CallOption) (*CancelSidecarResponse, error)
 }
 
@@ -446,146 +444,144 @@ func (c *traderClient) CancelSidecar(ctx context.Context, in *CancelSidecarReque
 // for forward compatibility
 type TraderServer interface {
 	// pool: `getinfo`
-	//GetInfo returns general information about the state of the Pool trader
-	//daemon.
+	// GetInfo returns general information about the state of the Pool trader
+	// daemon.
 	GetInfo(context.Context, *GetInfoRequest) (*GetInfoResponse, error)
 	// pool: `stop`
-	//Stop gracefully shuts down the Pool trader daemon.
+	// Stop gracefully shuts down the Pool trader daemon.
 	StopDaemon(context.Context, *StopDaemonRequest) (*StopDaemonResponse, error)
-	//
-	//QuoteAccount gets a fee quote to fund an account of the given size with the
-	//given confirmation target. If the connected lnd wallet doesn't have enough
-	//balance to fund an account of the requested size, an error is returned.
+	// QuoteAccount gets a fee quote to fund an account of the given size with the
+	// given confirmation target. If the connected lnd wallet doesn't have enough
+	// balance to fund an account of the requested size, an error is returned.
 	QuoteAccount(context.Context, *QuoteAccountRequest) (*QuoteAccountResponse, error)
 	// pool: `accounts new`
-	//InitAccount creates a new account with the requested size and expiration,
-	//funding it from the wallet of the connected lnd node.
+	// InitAccount creates a new account with the requested size and expiration,
+	// funding it from the wallet of the connected lnd node.
 	InitAccount(context.Context, *InitAccountRequest) (*Account, error)
 	// pool: `accounts list`
-	//ListAccounts returns a list of all accounts known to the trader daemon and
-	//their current state.
+	// ListAccounts returns a list of all accounts known to the trader daemon and
+	// their current state.
 	ListAccounts(context.Context, *ListAccountsRequest) (*ListAccountsResponse, error)
 	// pool: `accounts close`
-	//CloseAccount closes an account and returns the funds locked in that account
-	//to the connected lnd node's wallet.
+	// CloseAccount closes an account and returns the funds locked in that account
+	// to the connected lnd node's wallet.
 	CloseAccount(context.Context, *CloseAccountRequest) (*CloseAccountResponse, error)
 	// pool: `accounts withdraw`
-	//WithdrawAccount splits off parts of the account balance into the specified
-	//outputs while recreating the account with a reduced balance.
+	// WithdrawAccount splits off parts of the account balance into the specified
+	// outputs while recreating the account with a reduced balance.
 	WithdrawAccount(context.Context, *WithdrawAccountRequest) (*WithdrawAccountResponse, error)
 	// pool: `accounts deposit`
-	//DepositAccount adds more funds from the connected lnd node's wallet to an
-	//account.
+	// DepositAccount adds more funds from the connected lnd node's wallet to an
+	// account.
 	DepositAccount(context.Context, *DepositAccountRequest) (*DepositAccountResponse, error)
 	// pool: `accounts renew`
-	//RenewAccount renews the expiration of an account.
+	// RenewAccount renews the expiration of an account.
 	RenewAccount(context.Context, *RenewAccountRequest) (*RenewAccountResponse, error)
 	// pool: `accounts bumpfee`
-	//BumpAccountFee attempts to bump the fee of an account's transaction through
-	//child-pays-for-parent (CPFP). Since the CPFP is performed through the
-	//backing lnd node, the account transaction must contain an output under its
-	//control for a successful bump. If a CPFP has already been performed for an
-	//account, and this RPC is invoked again, then a replacing transaction (RBF)
-	//of the child will be broadcast.
+	// BumpAccountFee attempts to bump the fee of an account's transaction through
+	// child-pays-for-parent (CPFP). Since the CPFP is performed through the
+	// backing lnd node, the account transaction must contain an output under its
+	// control for a successful bump. If a CPFP has already been performed for an
+	// account, and this RPC is invoked again, then a replacing transaction (RBF)
+	// of the child will be broadcast.
 	BumpAccountFee(context.Context, *BumpAccountFeeRequest) (*BumpAccountFeeResponse, error)
 	// pool: `accounts recover`
-	//RecoverAccounts queries the auction server for this trader daemon's accounts
-	//in case we lost our local account database.
+	// RecoverAccounts queries the auction server for this trader daemon's accounts
+	// in case we lost our local account database.
 	RecoverAccounts(context.Context, *RecoverAccountsRequest) (*RecoverAccountsResponse, error)
 	// pool: `accounts listfees`
-	//AccountModificationFees returns a map from account key to an ordered list of
-	//account action modification fees.
+	// AccountModificationFees returns a map from account key to an ordered list of
+	// account action modification fees.
 	AccountModificationFees(context.Context, *AccountModificationFeesRequest) (*AccountModificationFeesResponse, error)
 	// pool: `orders submit`
-	//SubmitOrder creates a new ask or bid order and submits for the given account
-	//and submits it to the auction server for matching.
+	// SubmitOrder creates a new ask or bid order and submits for the given account
+	// and submits it to the auction server for matching.
 	SubmitOrder(context.Context, *SubmitOrderRequest) (*SubmitOrderResponse, error)
 	// pool: `orders list`
-	//ListOrders returns a list of all active and archived orders that are
-	//currently known to the trader daemon.
+	// ListOrders returns a list of all active and archived orders that are
+	// currently known to the trader daemon.
 	ListOrders(context.Context, *ListOrdersRequest) (*ListOrdersResponse, error)
 	// pool: `orders cancel`
-	//CancelOrder cancels an active order with the auction server to remove it
-	//from future matching.
+	// CancelOrder cancels an active order with the auction server to remove it
+	// from future matching.
 	CancelOrder(context.Context, *CancelOrderRequest) (*CancelOrderResponse, error)
-	//
-	//QuoteOrder calculates the premium, execution fees and max batch fee rate for
-	//an order based on the given order parameters.
+	// QuoteOrder calculates the premium, execution fees and max batch fee rate for
+	// an order based on the given order parameters.
 	QuoteOrder(context.Context, *QuoteOrderRequest) (*QuoteOrderResponse, error)
 	// pool: `auction fee`
-	//AuctionFee returns the current auction order execution fee specified by the
-	//auction server.
+	// AuctionFee returns the current auction order execution fee specified by the
+	// auction server.
 	AuctionFee(context.Context, *AuctionFeeRequest) (*AuctionFeeResponse, error)
 	// pool: `auction leasedurations`
-	//LeaseDurations returns the current set of valid lease duration in the
-	//market as is, and also information w.r.t if the market is currently active.
+	// LeaseDurations returns the current set of valid lease duration in the
+	// market as is, and also information w.r.t if the market is currently active.
 	LeaseDurations(context.Context, *LeaseDurationRequest) (*LeaseDurationResponse, error)
 	// pool: `auction nextbatchinfo`
-	//NextBatchInfo returns information about the next batch the auctioneer will
-	//perform.
+	// NextBatchInfo returns information about the next batch the auctioneer will
+	// perform.
 	NextBatchInfo(context.Context, *NextBatchInfoRequest) (*NextBatchInfoResponse, error)
 	// pool: `auction snapshot`
-	//BatchSnapshot returns the snapshot of a past batch identified by its ID.
-	//If no ID is provided, the snapshot of the last finalized batch is returned.
-	//Deprecated, use BatchSnapshots instead.
+	// BatchSnapshot returns the snapshot of a past batch identified by its ID.
+	// If no ID is provided, the snapshot of the last finalized batch is returned.
+	// Deprecated, use BatchSnapshots instead.
 	BatchSnapshot(context.Context, *auctioneerrpc.BatchSnapshotRequest) (*auctioneerrpc.BatchSnapshotResponse, error)
 	// pool: `listauth`
-	//GetLsatTokens returns all LSAT tokens the daemon ever paid for.
+	// GetLsatTokens returns all LSAT tokens the daemon ever paid for.
 	GetLsatTokens(context.Context, *TokensRequest) (*TokensResponse, error)
 	// pool: `auction leases`
-	//Leases returns the list of channels that were either purchased or sold by
-	//the trader within the auction.
+	// Leases returns the list of channels that were either purchased or sold by
+	// the trader within the auction.
 	Leases(context.Context, *LeasesRequest) (*LeasesResponse, error)
 	// pool: `auction ratings`
-	//Returns the Node Tier information for this target Lightning node, and other
-	//related ranking information.
+	// Returns the Node Tier information for this target Lightning node, and other
+	// related ranking information.
 	NodeRatings(context.Context, *NodeRatingRequest) (*NodeRatingResponse, error)
 	// pool: `auction snapshot`
-	//BatchSnapshots returns a list of batch snapshots starting at the start batch
-	//ID and going back through the history of batches, returning at most the
-	//number of specified batches. A maximum of 100 snapshots can be queried in
-	//one call. If no start batch ID is provided, the most recent finalized batch
-	//is used as the starting point to go back from.
+	// BatchSnapshots returns a list of batch snapshots starting at the start batch
+	// ID and going back through the history of batches, returning at most the
+	// number of specified batches. A maximum of 100 snapshots can be queried in
+	// one call. If no start batch ID is provided, the most recent finalized batch
+	// is used as the starting point to go back from.
 	BatchSnapshots(context.Context, *auctioneerrpc.BatchSnapshotsRequest) (*auctioneerrpc.BatchSnapshotsResponse, error)
 	// pool: `sidecar offer`
-	//OfferSidecar is step 1/4 of the sidecar negotiation between the provider
-	//(the trader submitting the bid order) and the recipient (the trader
-	//receiving the sidecar channel).
-	//This step must be run by the provider. The result is a sidecar ticket with
-	//an offer to lease a sidecar channel for the recipient. The offer will be
-	//signed with the provider's lnd node public key. The ticket returned by this
-	//call will have the state "offered".
+	// OfferSidecar is step 1/4 of the sidecar negotiation between the provider
+	// (the trader submitting the bid order) and the recipient (the trader
+	// receiving the sidecar channel).
+	// This step must be run by the provider. The result is a sidecar ticket with
+	// an offer to lease a sidecar channel for the recipient. The offer will be
+	// signed with the provider's lnd node public key. The ticket returned by this
+	// call will have the state "offered".
 	OfferSidecar(context.Context, *OfferSidecarRequest) (*SidecarTicket, error)
 	// pool: `sidecar register`
-	//RegisterSidecarRequest is step 2/4 of the sidecar negotiation between the
-	//provider (the trader submitting the bid order) and the recipient (the trader
-	//receiving the sidecar channel).
-	//This step must be run by the recipient. The result is a sidecar ticket with
-	//the recipient's node information and channel funding multisig pubkey filled
-	//in. The ticket returned by this call will have the state "registered".
+	// RegisterSidecarRequest is step 2/4 of the sidecar negotiation between the
+	// provider (the trader submitting the bid order) and the recipient (the trader
+	// receiving the sidecar channel).
+	// This step must be run by the recipient. The result is a sidecar ticket with
+	// the recipient's node information and channel funding multisig pubkey filled
+	// in. The ticket returned by this call will have the state "registered".
 	RegisterSidecar(context.Context, *RegisterSidecarRequest) (*SidecarTicket, error)
 	// pool: `sidecar expectchannel`
-	//ExpectSidecarChannel is step 4/4 of the sidecar negotiation between the
-	//provider (the trader submitting the bid order) and the recipient (the trader
-	//receiving the sidecar channel).
-	//This step must be run by the recipient once the provider has submitted the
-	//bid order for the sidecar channel. From this point onwards the Pool trader
-	//daemon of both the provider as well as the recipient need to be online to
-	//receive and react to match making events from the server.
+	// ExpectSidecarChannel is step 4/4 of the sidecar negotiation between the
+	// provider (the trader submitting the bid order) and the recipient (the trader
+	// receiving the sidecar channel).
+	// This step must be run by the recipient once the provider has submitted the
+	// bid order for the sidecar channel. From this point onwards the Pool trader
+	// daemon of both the provider as well as the recipient need to be online to
+	// receive and react to match making events from the server.
 	ExpectSidecarChannel(context.Context, *ExpectSidecarChannelRequest) (*ExpectSidecarChannelResponse, error)
 	// pool: `sidecar printticket`
-	//Decodes the base58 encoded sidecar ticket into its individual data fields
-	//for a more human-readable representation.
+	// Decodes the base58 encoded sidecar ticket into its individual data fields
+	// for a more human-readable representation.
 	DecodeSidecarTicket(context.Context, *SidecarTicket) (*DecodedSidecarTicket, error)
 	// pool: `sidecar list`
-	//ListSidecars lists all sidecar tickets currently in the local database. This
-	//includes tickets offered by our node as well as tickets that our node is the
-	//recipient of. Optionally a ticket ID can be provided to filter the tickets.
+	// ListSidecars lists all sidecar tickets currently in the local database. This
+	// includes tickets offered by our node as well as tickets that our node is the
+	// recipient of. Optionally a ticket ID can be provided to filter the tickets.
 	ListSidecars(context.Context, *ListSidecarsRequest) (*ListSidecarsResponse, error)
 	// pool: `sidecar cancel`
-	//CancelSidecar cancels the execution of a specific sidecar ticket. Depending
-	//on the state of the sidecar ticket its associated bid order might be
-	//canceled as well (if this ticket was offered by our node).
+	// CancelSidecar cancels the execution of a specific sidecar ticket. Depending
+	// on the state of the sidecar ticket its associated bid order might be
+	// canceled as well (if this ticket was offered by our node).
 	CancelSidecar(context.Context, *CancelSidecarRequest) (*CancelSidecarResponse, error)
 	mustEmbedUnimplementedTraderServer()
 }

--- a/poolscript/script.go
+++ b/poolscript/script.go
@@ -275,10 +275,11 @@ func (r *RecoveryHelper) LocateAnyOutput(expiry uint32,
 // AccountScript returns the output script of an account on-chain.
 //
 // For version 0 (p2wsh) this returns the hash of the following script:
-// <trader_key> OP_CHECKSIGVERIFY
-// <auctioneer_key> OP_CHECKSIG OP_IFDUP OP_NOTIF
-//	<account_expiry> OP_CHECKLOCKTIMEVERIFY
-// OP_ENDIF
+//
+//	<trader_key> OP_CHECKSIGVERIFY
+//	<auctioneer_key> OP_CHECKSIG OP_IFDUP OP_NOTIF
+//	        <account_expiry> OP_CHECKLOCKTIMEVERIFY
+//	OP_ENDIF
 //
 // For version 1 (p2tr) this returns the taproot key of a MuSig2 combined key
 // of the auctioneer's and trader's public keys as the internal key, tweaked

--- a/sidecar_acceptor.go
+++ b/sidecar_acceptor.go
@@ -25,13 +25,14 @@ import (
 
 // SidecarAcceptor is a type that is exclusively responsible for managing the
 // recipient's tasks of executing a sidecar channel. The two tasks are:
-// 1. Verify a sidecar ticket and the offer contained within then add the
-//    recipient node information to the ticket so it can be returned to the
-//    sidecar provider. This is step 2/4 of the entire sidecar execution
-//    protocol.
-// 2. Interact with the auction server and connect out to an asker's node in the
-//    right moment then accept the incoming channel. This is step 4/4 of the
-//    entire sidecar execution protocol.
+//  1. Verify a sidecar ticket and the offer contained within then add the
+//     recipient node information to the ticket so it can be returned to the
+//     sidecar provider. This is step 2/4 of the entire sidecar execution
+//     protocol.
+//  2. Interact with the auction server and connect out to an asker's node in the
+//     right moment then accept the incoming channel. This is step 4/4 of the
+//     entire sidecar execution protocol.
+//
 // The code for these two tasks are kept separate from the default funding
 // manager to make it easier to extract a standalone sidecar acceptor client
 // later on. It also makes it easier to see what code would need to be re-

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-buster
+FROM golang:1.19.4
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache


### PR DESCRIPTION
- Since Go v1.19.0 `go fmt` also formats commented code so files need to be reformated.
- Includes the fix for the lint complains about vsc

P.S: I can extract some of the steps in the actions in a comment one for  `Seting up Golang environment` if needed in this PR too