### PR TITLE
rpc: populate allowed/not allowed node ids when listing orders

### DIFF
--- a/order/rpc_parse_test.go
+++ b/order/rpc_parse_test.go
@@ -1,0 +1,94 @@
+package order
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var nodeIDSerializationTestCases = []struct {
+	name                  string
+	nodeIDs               func() [][33]byte
+	invalidSerializedData func() [][]byte
+	expectedErr           string
+}{{
+	name: "empty slice",
+	nodeIDs: func() [][33]byte {
+		return [][33]byte{}
+	},
+}, {
+	name: "single node id",
+	nodeIDs: func() [][33]byte {
+		return [][33]byte{
+			nodePubkey,
+		}
+	},
+}, {
+	name: "multiple node ids",
+	nodeIDs: func() [][33]byte {
+		nodeID, _ := hex.DecodeString("036b51e0cc2d9e5988ee4967e0ba67" +
+			"ef3727bb633fea21a0af58e0c9395446ba09")
+		var nodePubKey2 [33]byte
+		copy(nodePubKey2[:], nodeID)
+
+		return [][33]byte{
+			nodePubkey,
+			nodePubKey2,
+		}
+	},
+}, {
+	name: "invalid length",
+	invalidSerializedData: func() [][]byte {
+		return [][]byte{
+			{1, 2},
+		}
+	},
+	expectedErr: "invalid node_id length",
+}, {
+	name: "invalid pub key",
+	invalidSerializedData: func() [][]byte {
+		return MarshalNodeIDSlice([][33]byte{
+			{1, 2},
+		})
+	},
+	expectedErr: "invalid node_id:",
+}}
+
+// TestNodeIDSliceSerialization tests that we can properly serialize and
+// deserialize a slice of node ids.
+func TestNodeIDSliceSerialization(t *testing.T) {
+	for _, tc := range nodeIDSerializationTestCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			switch {
+			// Marshal and Unmarshal valid node ids.
+			case tc.nodeIDs != nil:
+				nodeIDs := tc.nodeIDs()
+				marshaled := MarshalNodeIDSlice(nodeIDs)
+				require.Equal(t, len(nodeIDs), len(marshaled))
+
+				unmarshaled, err := UnmarshalNodeIDSlice(
+					marshaled,
+				)
+
+				require.NoError(t, err)
+				require.Equal(t, tc.nodeIDs(), unmarshaled)
+
+			// Unmarshal invalid marshaled node ids.
+			case tc.invalidSerializedData != nil:
+				marshaled := tc.invalidSerializedData()
+
+				_, err := UnmarshalNodeIDSlice(marshaled)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+
+			default:
+				require.Fail(t, "invalid test case")
+			}
+		})
+	}
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1700,6 +1700,14 @@ func (s *rpcServer) ListOrders(ctx context.Context,
 			}
 		}
 
+		allowedNodeIDs := order.MarshalNodeIDSlice(
+			dbOrder.Details().AllowedNodeIDs,
+		)
+
+		notAllowedNodeIDs := order.MarshalNodeIDSlice(
+			dbOrder.Details().NotAllowedNodeIDs,
+		)
+
 		details := &poolrpc.Order{
 			TraderKey: dbDetails.AcctKey[:],
 			RateFixed: dbDetails.FixedRate,
@@ -1723,7 +1731,9 @@ func (s *rpcServer) ListOrders(ctx context.Context,
 			AuctionType: auctioneerrpc.AuctionType(
 				dbOrder.Details().AuctionType,
 			),
-			IsPublic: dbOrder.Details().IsPublic,
+			AllowedNodeIds:    allowedNodeIDs,
+			NotAllowedNodeIds: notAllowedNodeIDs,
+			IsPublic:          dbOrder.Details().IsPublic,
 		}
 
 		switch o := dbOrder.(type) {
@@ -1780,8 +1790,7 @@ func (s *rpcServer) ListOrders(ctx context.Context,
 			bids = append(bids, rpcBid)
 
 		default:
-			return nil, fmt.Errorf("unknown order type: %v",
-				o)
+			return nil, fmt.Errorf("unknown order type: %v", o)
 		}
 	}
 	return &poolrpc.ListOrdersResponse{

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -11,9 +11,6 @@ RUN cd /tmp \
   && mkdir -p /tmp/build/.modcache \
   && cd /tmp/tools \
   && go install -trimpath -tags=tools github.com/golangci/golangci-lint/cmd/golangci-lint \
-  && chmod -R 777 /tmp/build/ \
-  && git config --global --add safe.directory /build 
-  # The last line is needed to ensure that go build is able to gather 
-  # information from the vsc used in the builds to get the commit hash. 
+  && chmod -R 777 /tmp/build/
 
 WORKDIR /build


### PR DESCRIPTION
Fixes #428 
Depends on #427 
