### PR TITLE
build: remove Pool release targets no longer built for lnd

### DIFF
--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -3,11 +3,9 @@ VERSION_CHECK = @$(call print, "Building master with date version tag")
 
 BUILD_SYSTEM = darwin-amd64 \
 darwin-arm64 \
-dragonfly-amd64 \
 freebsd-386 \
 freebsd-amd64 \
 freebsd-arm \
-illumos-amd64 \
 linux-386 \
 linux-amd64 \
 linux-armv6 \
@@ -18,17 +16,9 @@ linux-ppc64le \
 linux-mips \
 linux-mipsle \
 linux-mips64 \
-linux-mips64le \
 linux-s390x \
-netbsd-386 \
 netbsd-amd64 \
-netbsd-arm \
-netbsd-arm64 \
-openbsd-386 \
 openbsd-amd64 \
-openbsd-arm \
-openbsd-arm64 \
-solaris-amd64 \
 windows-386 \
 windows-amd64 \
 windows-arm


### PR DESCRIPTION
lnd PR https://github.com/lightningnetwork/lnd/pull/7252/ removed support for 10 OS / architectures

As Pool requires lnd to run, this PR replicates the build list of lnd for Pool.

It is assumed that if a developer builds for an unsupported OS/architecture for their lnd binaries, the same will be done for Pool