### PR TITLE
version: bump to v0.6.2-beta

### DIFF
--- a/server.go
+++ b/server.go
@@ -60,11 +60,10 @@ var (
 	// muSig2V100RC2Version is the version of lnd that enabled the MuSig2
 	// v1.0.0-rc2 protocol in its MuSig2 RPC. We'll use this to decide what
 	// account version to default to.
-	// TODO(guggero): Update this to 0.16.0 when it's released.
 	muSig2V100RC2Version = &verrpc.Version{
 		AppMajor: 0,
-		AppMinor: 15,
-		AppPatch: 99,
+		AppMinor: 16,
+		AppPatch: 0,
 		BuildTags: []string{
 			"signrpc", "walletrpc", "chainrpc", "invoicesrpc",
 		},

--- a/version.go
+++ b/version.go
@@ -29,7 +29,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 6
-	appPatch uint = 1
+	appPatch uint = 2
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
Now that lnd `v0.16.0-beta.rc` is out we can target the right lnd version for `muSig2V100RC2Version`.

**Note**: we may want to set the minimum supported version for LND to `v0.16.0-beta`

