### PR TITLE
perms: move perms.go into poolrpc

### DIFF
--- a/poolrpc/perms.go
+++ b/poolrpc/perms.go
@@ -1,4 +1,4 @@
-package perms
+package poolrpc
 
 import "gopkg.in/macaroon-bakery.v2/bakery"
 

--- a/server.go
+++ b/server.go
@@ -24,7 +24,6 @@ import (
 	"github.com/lightninglabs/pool/clientdb"
 	"github.com/lightninglabs/pool/funding"
 	"github.com/lightninglabs/pool/order"
-	"github.com/lightninglabs/pool/perms"
 	"github.com/lightninglabs/pool/poolrpc"
 	"github.com/lightninglabs/pool/terms"
 	"github.com/lightningnetwork/lnd/kvdb"
@@ -199,7 +198,7 @@ func (s *Server) Start() error {
 			Checkers: []macaroons.Checker{
 				macaroons.IPLockChecker,
 			},
-			RequiredPerms: perms.RequiredPermissions,
+			RequiredPerms: poolrpc.RequiredPermissions,
 			DBPassword:    macDbDefaultPw,
 			LndClient:     &s.lndServices.LndServices,
 			EphemeralKey:  lndclient.SharedKeyNUMS,
@@ -425,7 +424,7 @@ func (s *Server) StartAsSubserver(lndClient lnrpc.LightningClient,
 				Checkers: []macaroons.Checker{
 					macaroons.IPLockChecker,
 				},
-				RequiredPerms: perms.RequiredPermissions,
+				RequiredPerms: poolrpc.RequiredPermissions,
 				DBPassword:    macDbDefaultPw,
 				LndClient:     &s.lndServices.LndServices,
 				EphemeralKey:  lndclient.SharedKeyNUMS,


### PR DESCRIPTION
Context: https://github.com/lightninglabs/lightning-node-connect/pull/114#discussion_r2078197455

---

This change narrows the import scope for lightning-node-connect (LNC). Instead of importing the entire pool package, LNC now only needs to import poolrpc.

It also brings pool in line with the structure used in our other projects.
