### PR TITLE
funding: fix stream handling issues in consumePendingOpenChannels

### DIFF
--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -99,6 +99,10 @@ type channelEventStream struct {
 	quit               chan struct{}
 }
 
+func (c *channelEventStream) Context() context.Context {
+	return c.ctx
+}
+
 func (c *channelEventStream) Recv() (*lnrpc.ChannelEventUpdate, error) {
 	select {
 	case msg := <-c.updateChan:


### PR DESCRIPTION
In this commit, we fix a few issues with the streaming handling:
  1. If it got an error on Recv() it would just spin for ever, generating an endless stream of spammy logs.
  2. It never listened on the Done() context channel for the stream. So if the `lnd` had actually hung up, it wouldn't detect that and would just keep spinning.

To make things more graceful, we also add back off when we try to reconnect.
