### PR TITLE
.github: add gateway workflow

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -1,0 +1,44 @@
+name: gateway
+
+# Consumer workflow shim for gateway.
+#
+# gateway fires on:
+#   - issue_comment.created          — a /gateway <command> comment on a PR
+#   - pull_request.review_requested  — GitHub Re-request review button
+#   - pull_request.closed            — cleanup on close/merge
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [review_requested, closed]
+
+permissions:
+  # The composite action mints an App installation token internally; the
+  # GITHUB_TOKEN handed to this shim is unused, so we minimise it.
+  contents: read
+
+jobs:
+  review:
+    # issue_comment fires for any issue. Filter to PR comments only.
+    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request != null }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: lightninglabs/gateway/.github/actions/review@v0.2.0
+        with:
+          event_name:      ${{ github.event_name }}
+          event_action:    ${{ github.event.action }}
+          repo:            ${{ github.repository }}
+          pr_number:       ${{ github.event.issue.number || github.event.pull_request.number }}
+          actor:           ${{ github.event.sender.login }}
+          comment_body:    ${{ github.event.comment.body }}
+          comment_id:      ${{ github.event.comment.id }}
+          installation_id: 131566347
+          # Credentials — passed as `with:` inputs (composite actions
+          # cannot declare a `secrets:` block). At least one of
+          # anthropic_api_key or claude_code_oauth_token must be set;
+          # both is fine — API is tried first, OAuth is fallback.
+          app_id:                  ${{ secrets.GATEWAY_APP_ID }}
+          private_key:             ${{ secrets.GATEWAY_PRIVATE_KEY }}
+          anthropic_api_key:       ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds the gateway consumer workflow shim that triggers on PR comments, review re-requests, and PR close events.
