### PR TITLE
version: bump to v0.7.0-beta

### DIFF
--- a/version.go
+++ b/version.go
@@ -28,8 +28,8 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 0
-	appMinor uint = 6
-	appPatch uint = 6
+	appMinor uint = 7
+	appPatch uint = 0
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
## Summary

Bumps the `poold` version to `v0.7.0-beta` ahead of cutting the release.

Notable changes included in this release line since `v0.6.6-beta`:

- `auctioneer`: reconnect on EOF instead of silently leaving the subscribe stream dead (#518).
- `auctioneer`: add jitter to the reconnect backoff (#518).
- `funding`: fix stream handling issues in `consumePendingOpenChannels` (#507).
- `.github`: add gateway workflow (#517).
- Several dependency bumps (`go-viper/mapstructure/v2`, `opencontainers/runc`, `golang-jwt/jwt/v4`, `golang.org/x/net`).

## Test plan

- [x] `go build ./...` passes locally.
- [ ] CI passes.